### PR TITLE
Replace use of home-grown test helpers

### DIFF
--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/honeycombio/hound/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAvgSampleUpdateMaps(t *testing.T) {
@@ -129,8 +129,8 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 	for i, tst := range tsts {
 		a.currentCounts = tst.inputSampleCount
 		a.updateMaps()
-		test.Equals(t, len(a.currentCounts), 0)
-		test.Equals(t, a.savedSampleRates, tst.expectedSavedSampleRates, fmt.Sprintf("test %d failed", i))
+		assert.Equal(t, len(a.currentCounts), 0)
+		assert.Equal(t, a.savedSampleRates, tst.expectedSavedSampleRates, fmt.Sprintf("test %d failed", i))
 	}
 }
 
@@ -160,7 +160,7 @@ func TestAvgSampleRateGetSampleRate(t *testing.T) {
 	}
 	for _, tst := range tsts {
 		rate := a.GetSampleRate(tst.inputKey)
-		test.Equals(t, rate, tst.expectedSampleRate)
-		test.Equals(t, a.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
+		assert.Equal(t, rate, tst.expectedSampleRate)
+		assert.Equal(t, a.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
 	}
 }

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/honeycombio/hound/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
@@ -147,8 +147,8 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 	for i, tst := range tsts {
 		a.currentCounts = tst.inputSampleCount
 		a.updateMaps()
-		test.Equals(t, len(a.currentCounts), 0)
-		test.Equals(t, a.savedSampleRates, tst.expectedSavedSampleRates, fmt.Sprintf("test %d failed", i))
+		assert.Equal(t, len(a.currentCounts), 0)
+		assert.Equal(t, a.savedSampleRates, tst.expectedSavedSampleRates, fmt.Sprintf("test %d failed", i))
 	}
 }
 
@@ -178,7 +178,7 @@ func TestAvgSampleWithMinGetSampleRate(t *testing.T) {
 	}
 	for _, tst := range tsts {
 		rate := a.GetSampleRate(tst.inputKey)
-		test.Equals(t, rate, tst.expectedSampleRate)
-		test.Equals(t, a.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
+		assert.Equal(t, rate, tst.expectedSampleRate)
+		assert.Equal(t, a.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
 	}
 }

--- a/onlyonce_test.go
+++ b/onlyonce_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/honeycombio/hound/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOnlyOnceUpdateMaps(t *testing.T) {
@@ -31,7 +31,7 @@ func TestOnlyOnceUpdateMaps(t *testing.T) {
 	for i, tst := range tsts {
 		o.seen = tst.inputSeen
 		o.updateMaps()
-		test.Equals(t, o.seen, tst.expectedSeen, fmt.Sprintf("test %d failed", i))
+		assert.Equal(t, o.seen, tst.expectedSeen, fmt.Sprintf("test %d failed", i))
 	}
 }
 
@@ -56,9 +56,9 @@ func TestOnlyOnceGetSampleRate(t *testing.T) {
 		{"four", 1000000000, true, true},
 	}
 	for _, tst := range tsts {
-		test.Equals(t, o.seen[tst.inputKey], tst.expectedCurrentCountForKeyBefore)
+		assert.Equal(t, o.seen[tst.inputKey], tst.expectedCurrentCountForKeyBefore)
 		rate := o.GetSampleRate(tst.inputKey)
-		test.Equals(t, rate, tst.expectedSampleRate)
-		test.Equals(t, o.seen[tst.inputKey], tst.expectedCurrentCountForKeyAfter)
+		assert.Equal(t, rate, tst.expectedSampleRate)
+		assert.Equal(t, o.seen[tst.inputKey], tst.expectedCurrentCountForKeyAfter)
 	}
 }

--- a/perkeythroughput_test.go
+++ b/perkeythroughput_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/honeycombio/hound/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPerKeyThroughputUpdateMaps(t *testing.T) {
@@ -146,8 +146,8 @@ func TestPerKeyThroughputUpdateMaps(t *testing.T) {
 	for i, tst := range tsts {
 		p.currentCounts = tst.inputCount
 		p.updateMaps()
-		test.Equals(t, len(p.currentCounts), 0)
-		test.Equals(t, p.savedSampleRates, tst.expectedSavedSampleRates, fmt.Sprintf("test %d failed", i))
+		assert.Equal(t, len(p.currentCounts), 0)
+		assert.Equal(t, p.savedSampleRates, tst.expectedSavedSampleRates, fmt.Sprintf("test %d failed", i))
 	}
 }
 
@@ -177,7 +177,7 @@ func TestPerKeyThroughputGetSampleRate(t *testing.T) {
 	}
 	for _, tst := range tsts {
 		rate := p.GetSampleRate(tst.inputKey)
-		test.Equals(t, rate, tst.expectedSampleRate)
-		test.Equals(t, p.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
+		assert.Equal(t, rate, tst.expectedSampleRate)
+		assert.Equal(t, p.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
 	}
 }

--- a/static_test.go
+++ b/static_test.go
@@ -3,7 +3,7 @@ package dynsampler
 import (
 	"testing"
 
-	"github.com/honeycombio/hound/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStaticGetSampleRate(t *testing.T) {
@@ -14,8 +14,8 @@ func TestStaticGetSampleRate(t *testing.T) {
 		},
 		Default: 3,
 	}
-	test.Equals(t, s.GetSampleRate("one"), 5)
-	test.Equals(t, s.GetSampleRate("two"), 10)
-	test.Equals(t, s.GetSampleRate("three"), 3)
+	assert.Equal(t, s.GetSampleRate("one"), 5)
+	assert.Equal(t, s.GetSampleRate("two"), 10)
+	assert.Equal(t, s.GetSampleRate("three"), 3)
 
 }

--- a/totalthroughput_test.go
+++ b/totalthroughput_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/honeycombio/hound/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTotalThroughputUpdateMaps(t *testing.T) {
@@ -130,8 +130,8 @@ func TestTotalThroughputUpdateMaps(t *testing.T) {
 	for i, tst := range tsts {
 		s.currentCounts = tst.inputSampleCount
 		s.updateMaps()
-		test.Equals(t, len(s.currentCounts), 0)
-		test.Equals(t, s.savedSampleRates, tst.expectedSavedSampleRates, fmt.Sprintf("test %d failed", i))
+		assert.Equal(t, len(s.currentCounts), 0)
+		assert.Equal(t, s.savedSampleRates, tst.expectedSavedSampleRates, fmt.Sprintf("test %d failed", i))
 	}
 }
 
@@ -161,7 +161,7 @@ func TestTotalThroughputGetSampleRate(t *testing.T) {
 	}
 	for _, tst := range tsts {
 		rate := s.GetSampleRate(tst.inputKey)
-		test.Equals(t, rate, tst.expectedSampleRate)
-		test.Equals(t, s.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
+		assert.Equal(t, rate, tst.expectedSampleRate)
+		assert.Equal(t, s.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
 	}
 }


### PR DESCRIPTION
Depending on honeycombio/hound/test causes interesting results when trying to
vendor this library in another project. Use the `assert` package from
github.com/stretchr/testify instead.