### PR TITLE
use the goal sample rate on startup

### DIFF
--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -140,9 +140,9 @@ func TestAvgSampleGetSampleRateStartup(t *testing.T) {
 		currentCounts:  map[string]int{},
 	}
 	rate := a.GetSampleRate("key")
-	test.Equals(t, rate, 10)
+	assert.Equal(t, rate, 10)
 	// and the counters still get bumped
-	test.Equals(t, a.currentCounts["key"], 1)
+	assert.Equal(t, a.currentCounts["key"], 1)
 }
 
 func TestAvgSampleRateGetSampleRate(t *testing.T) {

--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -134,8 +134,21 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 	}
 }
 
+func TestAvgSampleGetSampleRateStartup(t *testing.T) {
+	a := &AvgSampleRate{
+		GoalSampleRate: 10,
+		currentCounts:  map[string]int{},
+	}
+	rate := a.GetSampleRate("key")
+	test.Equals(t, rate, 10)
+	// and the counters still get bumped
+	test.Equals(t, a.currentCounts["key"], 1)
+}
+
 func TestAvgSampleRateGetSampleRate(t *testing.T) {
-	a := &AvgSampleRate{}
+	a := &AvgSampleRate{
+		haveData: true,
+	}
 	a.currentCounts = map[string]int{
 		"one": 5,
 		"two": 8,

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -158,9 +158,9 @@ func TestAvgSampleWithMinGetSampleRateStartup(t *testing.T) {
 		currentCounts:  map[string]int{},
 	}
 	rate := a.GetSampleRate("key")
-	test.Equals(t, rate, 10)
+	assert.Equal(t, rate, 10)
 	// and the counters still get bumped
-	test.Equals(t, a.currentCounts["key"], 1)
+	assert.Equal(t, a.currentCounts["key"], 1)
 }
 
 func TestAvgSampleWithMinGetSampleRate(t *testing.T) {

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -152,8 +152,21 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 	}
 }
 
+func TestAvgSampleWithMinGetSampleRateStartup(t *testing.T) {
+	a := &AvgSampleWithMin{
+		GoalSampleRate: 10,
+		currentCounts:  map[string]int{},
+	}
+	rate := a.GetSampleRate("key")
+	test.Equals(t, rate, 10)
+	// and the counters still get bumped
+	test.Equals(t, a.currentCounts["key"], 1)
+}
+
 func TestAvgSampleWithMinGetSampleRate(t *testing.T) {
-	a := &AvgSampleWithMin{}
+	a := &AvgSampleWithMin{
+		haveData: true,
+	}
 	a.currentCounts = map[string]int{
 		"one": 5,
 		"two": 8,


### PR DESCRIPTION
When starting a new process using the dynsampler, the old behavior was to treat every key as though it had not been seen and give it a sample rate of 1 for the first 30 seconds. The effect is that when dealing with high volume services, you sent a very large amount of traffic for the first 30 seconds. 

Instead of treating the startup period as though we were in a low volume setting, let's just use the goal sample rate on all traffic until we've gotten the first sample of traffic from which we can compute the dynamic sample rate.