### PR TITLE
add missing locking to AvgSampleWithMin

### DIFF
--- a/avgsamplewithmin.go
+++ b/avgsamplewithmin.go
@@ -100,6 +100,8 @@ func (a *AvgSampleWithMin) updateMaps() {
 		for k := range tmpCounts {
 			newSavedSampleRates[k] = 1
 		}
+		a.lock.Lock()
+		defer a.lock.Unlock()
 		a.savedSampleRates = newSavedSampleRates
 		return
 	}


### PR DESCRIPTION
While porting dynsampler-go to ruby (WIP here https://github.com/travis-ci/dynsampler-rb) I noticed a missing lock.

Perhaps I'm missing something, and it is not needed in this case. But it certainly looked suspicious. :)