### PR TITLE
Handle case where NaN values are computed in dynamic sampler

### DIFF
--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -125,7 +125,15 @@ func (a *AvgSampleRate) updateMaps() {
 		} else {
 			// there are more samples than the allotted number. Sample this key enough
 			// to knock it under the limit (aka round up)
-			newSavedSampleRates[key] = int(math.Ceil(count / goalForKey))
+			rate := math.Ceil(count / goalForKey)
+			// if counts are <= 1 we can get values for goalForKey that are +Inf
+			// and subsequent division ends up with NaN. If that's the case,
+			// fall back to 1
+			if math.IsNaN(rate) {
+				newSavedSampleRates[key] = 1
+			} else {
+				newSavedSampleRates[key] = int(rate)
+			}
 			extra += goalForKey - (count / float64(newSavedSampleRates[key]))
 		}
 	}

--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -164,7 +164,7 @@ func TestAvgSampleRace(t *testing.T) {
 			go func(i int) {
 				for j := 0; j < 1000; j++ {
 					rate := a.GetSampleRate("key" + strconv.Itoa(i))
-					assert.NotEqual(t, rate, 0, "rate should never be zero")
+					assert.NotEqual(t, rate <= 0, true, "rate should never be lte zero")
 				}
 				wg.Done()
 			}(i)

--- a/avgsamplewithmin.go
+++ b/avgsamplewithmin.go
@@ -111,6 +111,7 @@ func (a *AvgSampleWithMin) updateMaps() {
 	for _, count := range tmpCounts {
 		logSum += math.Log10(float64(count))
 	}
+	// Note that this can produce Inf if logSum is 0
 	goalRatio := goalCount / logSum
 
 	// must go through the keys in a fixed order to prevent rounding from changing
@@ -132,6 +133,7 @@ func (a *AvgSampleWithMin) updateMaps() {
 		count := float64(tmpCounts[key])
 		// take the max of 1 or my log10 share of the total
 		goalForKey := math.Max(1, math.Log10(count)*goalRatio)
+
 		// take this key's share of the extra and pass the rest along
 		extraForKey := extra / float64(keysRemaining)
 		goalForKey += extraForKey
@@ -145,7 +147,15 @@ func (a *AvgSampleWithMin) updateMaps() {
 		} else {
 			// there are more samples than the allotted number. Sample this key enough
 			// to knock it under the limit (aka round up)
-			newSavedSampleRates[key] = int(math.Ceil(count / goalForKey))
+			rate := math.Ceil(count / goalForKey)
+			// if counts are <= 1 we can get values for goalForKey that are +Inf
+			// and subsequent division ends up with NaN. If that's the case,
+			// fall back to 1
+			if math.IsNaN(rate) {
+				newSavedSampleRates[key] = 1
+			} else {
+				newSavedSampleRates[key] = int(rate)
+			}
 			extra += goalForKey - (count / float64(newSavedSampleRates[key]))
 		}
 	}

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -215,7 +215,7 @@ func TestAvgSampleWithMinRace(t *testing.T) {
 			go func(i int) {
 				for j := 0; j < 1000; j++ {
 					rate := a.GetSampleRate("key" + strconv.Itoa(i))
-					assert.NotEqual(t, rate, 0, "rate should never be zero")
+					assert.NotEqual(t, rate <= 0, true, "rate should never be lte zero", rate)
 				}
 				wg.Done()
 			}(i)


### PR DESCRIPTION
Step 1 in fixing https://github.com/honeycombio/honeytail/issues/123.

I am not really clear on the use of log10 to compute the "goalRatio" for each key in the dynamic sampler, but one issue can occur if all counts in any given interval are <= 1:

```
for _, count := range tmpCounts {
		logSum += math.Log10(float64(count))
}
```

In this case, logSum is 0, so when goalRatio is computed:

```
	goalRatio := goalCount / logSum
```

We get `+Inf` and ultimately return `int(NaN)` as the rate - causing `-9223372036854775808` to get passed to `rand.Intn` and a panic.

To prevent this, we can fallback to a rate of 1 if we compute NaN for goalRatio - which seems OK if all event counts are small.