### PR TITLE
Add MaxKeys option to AvgSampleRate sampler

### DIFF
--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -26,7 +26,9 @@ type AvgSampleRate struct {
 	GoalSampleRate int
 
 	// MaxKeys, if greater than 0, limits the number of distinct keys used to build
-	// the sample rate map.
+	// the sample rate map within the interval defined by `ClearFrequencySec`. Once
+	// MaxKeys is reached, new keys will not be included in the sample rate map, but
+	// existing keys will continue to be be counted.
 	MaxKeys int
 
 	savedSampleRates map[string]int

--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -212,3 +212,28 @@ func TestAvgSampleRateGetSampleRate(t *testing.T) {
 		assert.Equal(t, a.currentCounts[tst.inputKey], tst.expectedCurrentCountForKey)
 	}
 }
+
+func TestAvgSampleRateMaxKeys(t *testing.T) {
+	a := &AvgSampleRate{
+		MaxKeys: 3,
+	}
+	a.currentCounts = map[string]int{
+		"one": 1,
+		"two": 1,
+	}
+	a.savedSampleRates = map[string]int{}
+
+	// with MaxKeys 3, we are under the key limit, so three should get added
+	a.GetSampleRate("three")
+	assert.Equal(t, 3, len(a.currentCounts))
+	assert.Equal(t, 1, a.currentCounts["three"])
+	// Now we're at 3 keys - four should not be added
+	a.GetSampleRate("four")
+	assert.Equal(t, 3, len(a.currentCounts))
+	_, found := a.currentCounts["four"]
+	assert.Equal(t, false, found)
+	// We should still support bumping counts for existing keys
+	a.GetSampleRate("one")
+	assert.Equal(t, 3, len(a.currentCounts))
+	assert.Equal(t, 2, a.currentCounts["one"])
+}

--- a/perkeythroughput.go
+++ b/perkeythroughput.go
@@ -22,6 +22,12 @@ type PerKeyThroughput struct {
 	// throughput down to match the goal throughput. default 10
 	PerKeyThroughputPerSec int
 
+	// MaxKeys, if greater than 0, limits the number of distinct keys used to build
+	// the sample rate map within the interval defined by `ClearFrequencySec`. Once
+	// MaxKeys is reached, new keys will not be included in the sample rate map, but
+	// existing keys will continue to be be counted.
+	MaxKeys int
+
 	savedSampleRates map[string]int
 	currentCounts    map[string]int
 
@@ -87,7 +93,15 @@ func (p *PerKeyThroughput) updateMaps() {
 func (p *PerKeyThroughput) GetSampleRate(key string) int {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	p.currentCounts[key]++
+	// Enforce MaxKeys limit on the size of the map
+	if p.MaxKeys > 0 {
+		// If a key already exists, increment it. If not, but we're under the limit, store a new key
+		if _, found := p.currentCounts[key]; found || len(p.currentCounts) < p.MaxKeys {
+			p.currentCounts[key]++
+		}
+	} else {
+		p.currentCounts[key]++
+	}
 	if rate, found := p.savedSampleRates[key]; found {
 		return rate
 	}

--- a/totalthroughput.go
+++ b/totalthroughput.go
@@ -28,6 +28,12 @@ type TotalThroughput struct {
 	// goal throughput. Actual throughput may exceed goal throughput. default 100
 	GoalThroughputPerSec int
 
+	// MaxKeys, if greater than 0, limits the number of distinct keys used to build
+	// the sample rate map within the interval defined by `ClearFrequencySec`. Once
+	// MaxKeys is reached, new keys will not be included in the sample rate map, but
+	// existing keys will continue to be be counted.
+	MaxKeys int
+
 	savedSampleRates map[string]int
 	currentCounts    map[string]int
 
@@ -96,7 +102,15 @@ func (t *TotalThroughput) updateMaps() {
 func (t *TotalThroughput) GetSampleRate(key string) int {
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	t.currentCounts[key]++
+	// Enforce MaxKeys limit on the size of the map
+	if t.MaxKeys > 0 {
+		// If a key already exists, increment it. If not, but we're under the limit, store a new key
+		if _, found := t.currentCounts[key]; found || len(t.currentCounts) < t.MaxKeys {
+			t.currentCounts[key]++
+		}
+	} else {
+		t.currentCounts[key]++
+	}
 	if rate, found := t.savedSampleRates[key]; found {
 		return rate
 	}

--- a/totalthroughput_test.go
+++ b/totalthroughput_test.go
@@ -199,3 +199,28 @@ func TestTotalThroughputRace(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+func TestTotalThroughputMaxKeys(t *testing.T) {
+	tt := &TotalThroughput{
+		MaxKeys: 3,
+	}
+	tt.currentCounts = map[string]int{
+		"one": 1,
+		"two": 1,
+	}
+	tt.savedSampleRates = map[string]int{}
+
+	// with MaxKeys 3, we are under the key limit, so three should get added
+	tt.GetSampleRate("three")
+	assert.Equal(t, 3, len(tt.currentCounts))
+	assert.Equal(t, 1, tt.currentCounts["three"])
+	// Now we're at 3 keys - four should not be added
+	tt.GetSampleRate("four")
+	assert.Equal(t, 3, len(tt.currentCounts))
+	_, found := tt.currentCounts["four"]
+	assert.Equal(t, false, found)
+	// We should still support bumping counts for existing keys
+	tt.GetSampleRate("one")
+	assert.Equal(t, 3, len(tt.currentCounts))
+	assert.Equal(t, 2, tt.currentCounts["one"])
+}


### PR DESCRIPTION
It can be useful to put an upper bound on the memory used by the dynamic sampler, especially if you don't have control over the keys being submitted. If `MaxKeys` is set, enforce a maximum number of keys when collecting counts.