### PR TITLE
Add state persistence interface

### DIFF
--- a/avgsamplewithmin.go
+++ b/avgsamplewithmin.go
@@ -194,3 +194,13 @@ func (a *AvgSampleWithMin) GetSampleRate(key string) int {
 	}
 	return 1
 }
+
+// SaveState is not implemented
+func (a *AvgSampleWithMin) SaveState() ([]byte, error) {
+	return nil, nil
+}
+
+// LoadState is not implemented
+func (a *AvgSampleWithMin) LoadState(state []byte) error {
+	return nil
+}

--- a/doc.go
+++ b/doc.go
@@ -24,5 +24,9 @@ The following guidelines can help you choose a sampler. Depending on the shape o
 Each sampler implementation below has additional configuration parameters and a
 detailed description of how it chooses a sample rate.
 
+Some implementations implement `SaveState` and `LoadState` - enabling you to serialize the Sampler's internal state
+and load it back. This is useful, for example, if you want to avoid losing calculated sample rates between process
+restarts.
+
 */
 package dynsampler

--- a/dynsampler.go
+++ b/dynsampler.go
@@ -9,6 +9,7 @@ type Sampler interface {
 	// Start initializes the sampler. You should call Start() before using the
 	// sampler.
 	Start() error
+
 	// GetSampleRate will return the sample rate to use for the string given. You
 	// should call it with whatever key you choose to use to partition traffic
 	// into different sample rates.

--- a/dynsampler.go
+++ b/dynsampler.go
@@ -13,4 +13,12 @@ type Sampler interface {
 	// should call it with whatever key you choose to use to partition traffic
 	// into different sample rates.
 	GetSampleRate(string) int
+
+	// SaveState returns a byte array containing the state of the Sampler implementation.
+	// It can be used to persist state between process restarts.
+	SaveState() ([]byte, error)
+
+	// LoadState accepts a byte array containing the serialized, previous state of the sampler
+	// implementation. It should be called before `Start`.
+	LoadState([]byte) error
 }

--- a/onlyonce.go
+++ b/onlyonce.go
@@ -65,3 +65,13 @@ func (o *OnlyOnce) GetSampleRate(key string) int {
 	o.seen[key] = true
 	return 1
 }
+
+// SaveState is not implemented
+func (o *OnlyOnce) SaveState() ([]byte, error) {
+	return nil, nil
+}
+
+// LoadState is not implemented
+func (o *OnlyOnce) LoadState(state []byte) error {
+	return nil
+}

--- a/perkeythroughput.go
+++ b/perkeythroughput.go
@@ -107,3 +107,13 @@ func (p *PerKeyThroughput) GetSampleRate(key string) int {
 	}
 	return 1
 }
+
+// SaveState is not implemented
+func (p *PerKeyThroughput) SaveState() ([]byte, error) {
+	return nil, nil
+}
+
+// LoadState is not implemented
+func (p *PerKeyThroughput) LoadState(state []byte) error {
+	return nil
+}

--- a/static.go
+++ b/static.go
@@ -26,3 +26,13 @@ func (s *Static) GetSampleRate(key string) int {
 	}
 	return s.Default
 }
+
+// SaveState is not implemented
+func (s *Static) SaveState() ([]byte, error) {
+	return nil, nil
+}
+
+// LoadState is not implemented
+func (s *Static) LoadState(state []byte) error {
+	return nil
+}

--- a/totalthroughput.go
+++ b/totalthroughput.go
@@ -116,3 +116,13 @@ func (t *TotalThroughput) GetSampleRate(key string) int {
 	}
 	return 1
 }
+
+// SaveState is not implemented
+func (t *TotalThroughput) SaveState() ([]byte, error) {
+	return nil, nil
+}
+
+// LoadState is not implemented
+func (t *TotalThroughput) LoadState(state []byte) error {
+	return nil
+}


### PR DESCRIPTION
Losing sampler state between process restarts can be problematic, depending on the application. Adds a SaveState/LoadState interface to serialize and load state, and an initial implementation in AvgSampleRate.