### PR TITLE
[emasamplerate] Fix inaccuracies with low throughputs/small counts

### DIFF
--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -131,6 +131,52 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 			map[string]int{},
 			map[string]int{},
 		},
+		{
+			map[string]int{
+				"one":       10,
+				"two":       1,
+				"three":     1,
+				"four":      1,
+				"five":      1,
+				"six":       1,
+				"seven":     1,
+				"eight":     1,
+				"nine":      1,
+				"ten":       1,
+				"eleven":    1,
+				"twelve":    1,
+				"thirteen":  1,
+				"fourteen":  1,
+				"fifteen":   1,
+				"sixteen":   1,
+				"seventeen": 1,
+				"eighteen":  1,
+				"nineteen":  1,
+				"twenty":    1,
+			},
+			map[string]int{
+				"one":       7,
+				"two":       1,
+				"three":     1,
+				"four":      1,
+				"five":      1,
+				"six":       1,
+				"seven":     1,
+				"eight":     1,
+				"nine":      1,
+				"ten":       1,
+				"eleven":    1,
+				"twelve":    1,
+				"thirteen":  1,
+				"fourteen":  1,
+				"fifteen":   1,
+				"sixteen":   1,
+				"seventeen": 1,
+				"eighteen":  1,
+				"nineteen":  1,
+				"twenty":    1,
+			},
+		},
 	}
 	for i, tst := range tsts {
 		a.currentCounts = tst.inputSampleCount
@@ -335,6 +381,29 @@ func TestAvgSampleRateHitsTargetRate(t *testing.T) {
 			assert.True(t, success/100.0 >= 0.95, "target rate test %d with key count %d failed with success rate of only %f", rate, keyCount, success/100.0)
 		}
 	}
+}
+
+func TestAvgSampleUpdateMapsSparseCounts(t *testing.T) {
+	a := &AvgSampleRate{
+		GoalSampleRate: 20,
+	}
+
+	a.savedSampleRates = make(map[string]int)
+
+	for i := 0; i <= 100; i++ {
+		input := make(map[string]int)
+		// simulate steady stream of input from one key
+		input["largest_count"] = 20
+		// sporadic keys with single counts that come and go with each interval
+		for j := 0; j < 5; j++ {
+			key := randomString(8)
+			input[key] = 1
+		}
+		a.currentCounts = input
+		a.updateMaps()
+	}
+
+	assert.Equal(t, 16, a.savedSampleRates["largest_count"])
 }
 
 func randomString(length int) string {

--- a/emasamplerate_test.go
+++ b/emasamplerate_test.go
@@ -175,6 +175,52 @@ func TestEMASampleUpdateMaps(t *testing.T) {
 			map[string]float64{},
 			map[string]int{},
 		},
+		{
+			map[string]float64{
+				"one":       10,
+				"two":       1,
+				"three":     1,
+				"four":      1,
+				"five":      1,
+				"six":       1,
+				"seven":     1,
+				"eight":     1,
+				"nine":      1,
+				"ten":       1,
+				"eleven":    1,
+				"twelve":    1,
+				"thirteen":  1,
+				"fourteen":  1,
+				"fifteen":   1,
+				"sixteen":   1,
+				"seventeen": 1,
+				"eighteen":  1,
+				"nineteen":  1,
+				"twenty":    1,
+			},
+			map[string]int{
+				"one":       7,
+				"two":       1,
+				"three":     1,
+				"four":      1,
+				"five":      1,
+				"six":       1,
+				"seven":     1,
+				"eight":     1,
+				"nine":      1,
+				"ten":       1,
+				"eleven":    1,
+				"twelve":    1,
+				"thirteen":  1,
+				"fourteen":  1,
+				"fifteen":   1,
+				"sixteen":   1,
+				"seventeen": 1,
+				"eighteen":  1,
+				"nineteen":  1,
+				"twenty":    1,
+			},
+		},
 	}
 	for i, tst := range tsts {
 		e.movingAverage = make(map[string]float64)
@@ -195,6 +241,31 @@ func TestEMASampleUpdateMaps(t *testing.T) {
 		assert.Equal(t, 0, len(e.currentCounts))
 		assert.Equal(t, tst.expectedSavedSampleRates, e.savedSampleRates, fmt.Sprintf("test %d failed", i))
 	}
+}
+
+func TestEMASampleUpdateMapsSparseCounts(t *testing.T) {
+	e := &EMASampleRate{
+		GoalSampleRate: 20,
+		Weight:         0.2,
+		AgeOutValue:    0.2,
+	}
+
+	e.movingAverage = make(map[string]float64)
+	e.savedSampleRates = make(map[string]int)
+
+	for i := 0; i <= 100; i++ {
+		input := make(map[string]float64)
+		// simulate steady stream of input from one key
+		input["largest_count"] = 20
+		// sporadic keys with single counts that come and go with each interval
+		for j := 0; j < 5; j++ {
+			key := randomString(8)
+			input[key] = 1
+		}
+		e.currentCounts = input
+		e.updateMaps()
+	}
+	assert.Equal(t, 16, e.savedSampleRates["largest_count"])
 }
 
 func TestEMAAgesOutSmallValues(t *testing.T) {
@@ -359,7 +430,6 @@ func TestEMASampleRateHitsTargetRate(t *testing.T) {
 				}
 
 				avgSampleRate := float64(totalSampleRate) / float64(totalKeptObservations)
-				fmt.Println(toleranceLower, avgSampleRate, toleranceUpper)
 				if avgSampleRate <= toleranceUpper && avgSampleRate >= toleranceLower {
 					success++
 				}


### PR DESCRIPTION
Adapting the AvgSampleRate implementation, which uses integers, to the Exponential Moving Average, which uses floats, introduced some inaccuracies with very small counts, which end up in the EMA at < 1. This results in their log being < 0, and skews `logSum` to be smaller than it would have been computed in the AvgSampleRate implementation. All this adds up to less accurate sample rate calculations when counts are small or there are a lot of keys with counts < 1. This change puts a floor on the EMA counts at 1 for the purposes of doing the log curve mapping.

I added two tests:
- TestEMASampleUpdateMapsSparseCounts
- TestAvgSampleUpdateMapsSparseCounts

These should be equal, but before my EMASampleRate changes, the EMA test got a sample rate of 5 while the AvgSampleRate test got a sample rate value of 16.

Note that no changes occurred in the expected output of `TestEMASampleUpdateMaps`, which further suggests this was an edge case only affecting small counts.