### PR TITLE
Update go version in circleci workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,23 @@ version: 2.1
 orbs:
   buildevents: honeycombio/buildevents@0.2.3
 
+matrix_goversions: &matrix_goversions
+  matrix:
+    parameters:
+      goversion: ["12", "13", "14", "15", "16", "17"]
+
+# Default version of Go to use for Go steps
+default_goversion: &default_goversion "17"
+
 executors:
   go:
     parameters:
       goversion:
         type: string
-        default: "17"
-    working_directory: /go/src/github.com/honeycombio/dynsampler-go
+        default: *default_goversion
+    working_directory: /home/circleci/go/src/github.com/honeycombio/dynsampler-go
     docker:
-      - image: circleci/golang:1.<< parameters.goversion >>
+      - image: cimg/go:1.<< parameters.goversion >>
 
 jobs:
   setup:
@@ -27,13 +35,20 @@ jobs:
     parameters:
       goversion:
         type: string
-        default: "17"
+        default: *default_goversion
     executor:
       name: go
       goversion: "<< parameters.goversion >>"
     steps:
       - buildevents/with_job_span:
           steps:
+            - when:
+                condition:
+                  equal: ["12", "<< parameters.goversion >>" ]
+                steps:
+                  - run:
+                      name: Update certs in old CI image
+                      command: sudo apt-get update && sudo apt-get install -y ca-certificates
             - checkout
             - run: go get -v -t -d ./...
             - run: go test -race -v ./...
@@ -49,8 +64,6 @@ workflows:
           requires:
             - setup
       - test_dynsampler:
+          <<: *matrix_goversions
           requires:
             - setup
-          matrix:
-            parameters:
-              goversion: ["10", "11", "12", "13", "14", "15", "16", "17"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - buildevents/watch_build_and_finish
 
-  test_dynsampler:
+  test:
     parameters:
       goversion:
         type: string
@@ -59,13 +59,13 @@ jobs:
                 field_value: << parameters.goversion >>
 
 workflows:
-  build_dynsampler:
+  test:
     jobs:
       - setup
       - watch:
           requires:
             - setup
-      - test_dynsampler:
+      - test:
           <<: *matrix_goversions
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ executors:
       goversion:
         type: string
         default: *default_goversion
-    working_directory: /home/circleci/go/src/github.com/honeycombio/dynsampler-go
     docker:
       - image: cimg/go:1.<< parameters.goversion >>
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ executors:
     working_directory: /home/circleci/go/src/github.com/honeycombio/dynsampler-go
     docker:
       - image: cimg/go:1.<< parameters.goversion >>
+        environment:
+          GO111MODULE: "on"
 
 jobs:
   setup:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     parameters:
       goversion:
         type: string
-        default: "12"
+        default: "17"
     working_directory: /go/src/github.com/honeycombio/dynsampler-go
     docker:
       - image: circleci/golang:1.<< parameters.goversion >>
@@ -27,7 +27,7 @@ jobs:
     parameters:
       goversion:
         type: string
-        default: "12"
+        default: "17"
     executor:
       name: go
       goversion: "<< parameters.goversion >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,14 +49,8 @@ workflows:
           requires:
             - setup
       - test_dynsampler:
-          goversion: "10"
           requires:
             - setup
-      - test_dynsampler:
-          goversion: "11"
-          requires:
-            - setup
-      - test_dynsampler:
-          goversion: "12"
-          requires:
-            - setup
+          matrix:
+            parameters:
+              goversion: ["10", "11", "12", "13", "14", "15", "16", "17"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/honeycombio/dynsampler-go
+
+go 1.12
+
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates go to v1.17.

- Closes #18 

## Short description of the changes
- updates go default version to v1.17 in circleci workflows
- drops testing against go 1.10 and 1.11
- matrix'd tests for Go 1.12 - 1.17
- updated to use Circle's "new" cimg/go images
- [migrated to Go modules](https://go.dev/blog/migrating-to-go-modules)
- renamed the job _and_ workflow to "test" because that's all we're doing here