### PR TITLE
maint: add go 1.18 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ orbs:
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["12", "13", "14", "15", "16", "17"]
+      goversion: ["12", "13", "14", "15", "16", "17", "18"]
 
 # Default version of Go to use for Go steps
-default_goversion: &default_goversion "17"
+default_goversion: &default_goversion "18"
 
 executors:
   go:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- go 1.18 was released earlier this month

## Short description of the changes

- add 1.18 to test matrix
- change default go version to 1.18

