### PR TITLE
ci: fix releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ executors:
       - image: cimg/go:1.<< parameters.goversion >>
         environment:
           GO111MODULE: "on"
-  github:
-    docker:
-      - image: cibuilds/github:0.13.0
 
 jobs:
   setup:
@@ -69,10 +66,13 @@ jobs:
                 field_value: << parameters.goversion >>
 
   publish_github:
-    executor: github
+    executor: go
     steps:
       - attach_workspace:
           at: ~/
+      - run:
+          name: Install ghr for drafting GitHub Releases
+          command: go install github.com/tcnksm/ghr@latest
       - run:
           name: "create draft release at GitHub"
           command: make publish_github

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,9 @@ workflows:
   build:
     jobs:
       - setup
+          <<: *filters_always
       - watch:
+          <<: *filters_always
           requires:
             - setup
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,7 @@ jobs:
   publish_github:
     executor: go
     steps:
-      - attach_workspace:
-          at: ~/
+      - checkout
       - run:
           name: Install ghr for drafting GitHub Releases
           command: go install github.com/tcnksm/ghr@latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
 workflows:
   build:
     jobs:
-      - setup
+      - setup:
           <<: *filters_always
       - watch:
           <<: *filters_always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,4 +94,4 @@ workflows:
           <<: *filters_publish
           context: Honeycomb Secrets for Public Repos
           requires:
-            - setup
+            - test


### PR DESCRIPTION
## Which problem is this PR solving?

- Circle CI wouldn't run the new `publish_github` job.

## Short description of the changes

- The "always match" filter needed to be added to the `setup` job else it wouldn't run for tagging events and thereby prevent `publish_github` from running.
- Use the `go` executor instead of `github` so we can have the make command.
- Arrange for `publish_github` after tests pass because we shouldn't release things that could be broken!
