### PR TITLE
fix: Fix flaky blocklist test

### DIFF
--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -177,11 +177,12 @@ func compareConcurrency(t *testing.T, reference BlockList, actual BlockList) {
 			case <-done:
 				return
 			case <-updateTicker.C:
-				currentIndex := atomic.LoadInt64(&globalIndex)
 
 				lock.Lock()
+				currentIndex := atomic.LoadInt64(&globalIndex)
 				referenceAggregate := reference.AggregateCounts(currentIndex, 10)
 				actualAggregate := actual.AggregateCounts(currentIndex, 10)
+
 				assert.Equal(t, referenceAggregate, actualAggregate)
 				lock.Unlock()
 			}
@@ -194,13 +195,14 @@ func compareConcurrency(t *testing.T, reference BlockList, actual BlockList) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
-				currentIndex := atomic.LoadInt64(&globalIndex)
 
 				// These need to be performed atomically.
 				lock.Lock()
+				currentIndex := atomic.LoadInt64(&globalIndex)
 				referenceErr := reference.IncrementKey(testKey, currentIndex)
 				actualErr := actual.IncrementKey(testKey, currentIndex)
 				assert.Equal(t, referenceErr, actualErr)
+
 				sleepTime := time.Duration(random.Intn(100)) * time.Millisecond
 				lock.Unlock()
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

This is re: https://github.com/honeycombio/dynsampler-go/pull/45#issuecomment-1458856457

The original code has a rare race condition:

1) On line 180, the `currentIndex` is loaded
2) Context switch to where `currentIndex` is incremented
3) `IncrementKey` is called on the updated index
4) `AggregateCounts` is called on an old `currentIndex`. This is undefined behavior, as `currentIndex` is assumed to be monotonically increasing. 

To validate that this race condition was fixed, I wrote a script that ran the test 100 times.

With the previous code, I observed 7 failures out of 100 runs.

With the new code, I observed 0 failures out of 100 runs.

## Short description of the changes

Small change to unit tests.
