### PR TITLE
feat: Add Stop() function to shut down a sampler

### DIFF
--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -40,6 +40,7 @@ type AvgSampleRate struct {
 	// gotten any samples of traffic, we should we should use the default goal
 	// sample rate for all events instead of sampling everything at 1
 	haveData bool
+	done     chan struct{}
 
 	lock sync.Mutex
 }
@@ -62,14 +63,26 @@ func (a *AvgSampleRate) Start() error {
 		a.savedSampleRates = make(map[string]int)
 	}
 	a.currentCounts = make(map[string]int)
+	a.done = make(chan struct{})
 
 	// spin up calculator
 	go func() {
 		ticker := time.NewTicker(time.Second * time.Duration(a.ClearFrequencySec))
-		for range ticker.C {
-			a.updateMaps()
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				a.updateMaps()
+			case <-a.done:
+				return
+			}
 		}
 	}()
+	return nil
+}
+
+func (a *AvgSampleRate) Stop() error {
+	close(a.done)
 	return nil
 }
 

--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -307,8 +307,7 @@ func TestAvgSampleRateSaveState(t *testing.T) {
 	state, err := sampler.SaveState()
 	assert.Nil(t, err)
 
-	var newSampler Sampler
-	newSampler = &AvgSampleRate{}
+	var newSampler Sampler = &AvgSampleRate{}
 
 	err = newSampler.LoadState(state)
 	assert.Nil(t, err)

--- a/dynsampler.go
+++ b/dynsampler.go
@@ -10,6 +10,9 @@ type Sampler interface {
 	// sampler.
 	Start() error
 
+	// Stop halts the sampler and any background goroutines
+	Stop() error
+
 	// GetSampleRate will return the sample rate to use for the given key
 	// string. You should call it with whatever key you choose to use to
 	// partition traffic into different sample rates. It assumes that you're

--- a/static.go
+++ b/static.go
@@ -21,6 +21,10 @@ func (s *Static) Start() error {
 	return nil
 }
 
+func (s *Static) Stop() error {
+	return nil
+}
+
 // GetSampleRate takes a key and returns the appropriate sample rate for that
 // key.
 func (s *Static) GetSampleRate(key string) int {


### PR DESCRIPTION
## Which problem is this PR solving?

This PR adjusts the `kent.event_counts` branch (see #53) to include a Stop() function so that the samplers can be shut down properly. This is currently only useful in tests.

## Short description of the changes

- Add stop function.

