### PR TITLE
maint: bump the go versions we support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,10 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["16", "17", "18", "19"]
+      goversion: ["17", "18", "19", "20"]
 
 # Default version of Go to use for Go steps
-default_goversion: &default_goversion "18"
+default_goversion: &default_goversion "20"
 
 executors:
   go:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/honeycombio/dynsampler-go
 
-go 1.12
+go 1.17
 
 require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)


### PR DESCRIPTION
This updates the Go versions supported and tested by this module to go 1.17 and above.