### PR TITLE
maint: Pull out common calculation into a function

### DIFF
--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -18,11 +18,11 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 		GoalSampleRate: 20,
 	}
 	tsts := []struct {
-		inputSampleCount         map[string]int
+		inputSampleCount         map[string]float64
 		expectedSavedSampleRates map[string]int
 	}{
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   1,
 				"two":   1,
 				"three": 2,
@@ -48,7 +48,7 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   1,
 				"two":   1,
 				"three": 2,
@@ -72,7 +72,7 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   1,
 				"two":   1,
 				"three": 2,
@@ -88,7 +88,7 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   1000,
 				"two":   1000,
 				"three": 2000,
@@ -104,7 +104,7 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   6000,
 				"two":   6000,
 				"three": 6000,
@@ -120,7 +120,7 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one": 12000,
 			},
 			map[string]int{
@@ -128,11 +128,11 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{},
+			map[string]float64{},
 			map[string]int{},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":       10,
 				"two":       1,
 				"three":     1,
@@ -189,18 +189,18 @@ func TestAvgSampleUpdateMaps(t *testing.T) {
 func TestAvgSampleGetSampleRateStartup(t *testing.T) {
 	a := &AvgSampleRate{
 		GoalSampleRate: 10,
-		currentCounts:  map[string]int{},
+		currentCounts:  map[string]float64{},
 	}
 	rate := a.GetSampleRate("key")
 	assert.Equal(t, rate, 10)
 	// and the counters still get bumped
-	assert.Equal(t, a.currentCounts["key"], 1)
+	assert.Equal(t, a.currentCounts["key"], 1.0)
 }
 
 func TestAvgSampleRace(t *testing.T) {
 	a := &AvgSampleRate{
 		GoalSampleRate:   2,
-		currentCounts:    map[string]int{},
+		currentCounts:    map[string]float64{},
 		savedSampleRates: map[string]int{},
 		haveData:         true,
 	}
@@ -234,7 +234,7 @@ func TestAvgSampleRateGetSampleRate(t *testing.T) {
 	a := &AvgSampleRate{
 		haveData: true,
 	}
-	a.currentCounts = map[string]int{
+	a.currentCounts = map[string]float64{
 		"one": 5,
 		"two": 8,
 	}
@@ -246,7 +246,7 @@ func TestAvgSampleRateGetSampleRate(t *testing.T) {
 	tsts := []struct {
 		inputKey                   string
 		expectedSampleRate         int
-		expectedCurrentCountForKey int
+		expectedCurrentCountForKey float64
 	}{
 		{"one", 10, 6},
 		{"two", 1, 9},
@@ -267,7 +267,7 @@ func TestAvgSampleRateMaxKeys(t *testing.T) {
 	a := &AvgSampleRate{
 		MaxKeys: 3,
 	}
-	a.currentCounts = map[string]int{
+	a.currentCounts = map[string]float64{
 		"one": 1,
 		"two": 1,
 	}
@@ -276,7 +276,7 @@ func TestAvgSampleRateMaxKeys(t *testing.T) {
 	// with MaxKeys 3, we are under the key limit, so three should get added
 	a.GetSampleRate("three")
 	assert.Equal(t, 3, len(a.currentCounts))
-	assert.Equal(t, 1, a.currentCounts["three"])
+	assert.Equal(t, 1., a.currentCounts["three"])
 	// Now we're at 3 keys - four should not be added
 	a.GetSampleRate("four")
 	assert.Equal(t, 3, len(a.currentCounts))
@@ -285,7 +285,7 @@ func TestAvgSampleRateMaxKeys(t *testing.T) {
 	// We should still support bumping counts for existing keys
 	a.GetSampleRate("one")
 	assert.Equal(t, 3, len(a.currentCounts))
-	assert.Equal(t, 2, a.currentCounts["one"])
+	assert.Equal(t, 2., a.currentCounts["one"])
 }
 
 func TestAvgSampleRateSaveState(t *testing.T) {
@@ -334,7 +334,7 @@ func TestAvgSampleRateHitsTargetRate(t *testing.T) {
 		toleranceLower := float64(rate) - tolerance
 
 		for _, keyCount := range testKeyCount {
-			sampler := &AvgSampleRate{GoalSampleRate: rate, currentCounts: make(map[string]int)}
+			sampler := &AvgSampleRate{GoalSampleRate: rate, currentCounts: make(map[string]float64)}
 
 			// build a consistent set of keys to use
 			keys := make([]string, keyCount)
@@ -347,7 +347,7 @@ func TestAvgSampleRateHitsTargetRate(t *testing.T) {
 				// so that count ranges are reasonable (i.e. they don't go from 1 to 10000 back to 100)
 				base := math.Pow10(i%3 + 1)
 				count := float64(((i%10)+1))*base + float64(mrand.Intn(int(base)))
-				sampler.currentCounts[key] = int(count)
+				sampler.currentCounts[key] = count
 			}
 
 			// build an initial set of sample rates so we don't just return the target rate
@@ -390,7 +390,7 @@ func TestAvgSampleUpdateMapsSparseCounts(t *testing.T) {
 	a.savedSampleRates = make(map[string]int)
 
 	for i := 0; i <= 100; i++ {
-		input := make(map[string]int)
+		input := make(map[string]float64)
 		// simulate steady stream of input from one key
 		input["largest_count"] = 20
 		// sporadic keys with single counts that come and go with each interval

--- a/avgsamplewithmin.go
+++ b/avgsamplewithmin.go
@@ -2,7 +2,6 @@ package dynsampler
 
 import (
 	"math"
-	"sort"
 	"sync"
 	"time"
 )
@@ -38,7 +37,7 @@ type AvgSampleWithMin struct {
 	MinEventsPerSec int
 
 	savedSampleRates map[string]int
-	currentCounts    map[string]int
+	currentCounts    map[string]float64
 
 	// haveData indicates that we have gotten a sample of traffic. Before we've
 	// gotten any samples of traffic, we should we should use the default goal
@@ -66,7 +65,7 @@ func (a *AvgSampleWithMin) Start() error {
 
 	// initialize internal variables
 	a.savedSampleRates = make(map[string]int)
-	a.currentCounts = make(map[string]int)
+	a.currentCounts = make(map[string]float64)
 	a.done = make(chan struct{})
 
 	// spin up calculator
@@ -96,7 +95,7 @@ func (a *AvgSampleWithMin) updateMaps() {
 	// make a local copy of the sample counters for calculation
 	a.lock.Lock()
 	tmpCounts := a.currentCounts
-	a.currentCounts = make(map[string]int)
+	a.currentCounts = make(map[string]float64)
 	a.lock.Unlock()
 	newSavedSampleRates := make(map[string]int)
 	// short circuit if no traffic
@@ -111,13 +110,13 @@ func (a *AvgSampleWithMin) updateMaps() {
 
 	// Goal events to send this interval is the total count of received events
 	// divided by the desired average sample rate
-	var sumEvents int
+	var sumEvents float64
 	for _, count := range tmpCounts {
 		sumEvents += count
 	}
 	goalCount := float64(sumEvents) / float64(a.GoalSampleRate)
 	// check to see if we fall below the minimum
-	if sumEvents < a.MinEventsPerSec*a.ClearFrequencySec {
+	if sumEvents < float64(a.MinEventsPerSec*a.ClearFrequencySec) {
 		// we still need to go through each key to set sample rates individually
 		for k := range tmpCounts {
 			newSavedSampleRates[k] = 1
@@ -136,51 +135,7 @@ func (a *AvgSampleWithMin) updateMaps() {
 	// Note that this can produce Inf if logSum is 0
 	goalRatio := goalCount / logSum
 
-	// must go through the keys in a fixed order to prevent rounding from changing
-	// results
-	keys := make([]string, len(tmpCounts))
-	var i int
-	for k := range tmpCounts {
-		keys[i] = k
-		i++
-	}
-	sort.Strings(keys)
-
-	// goal number of events per key is goalRatio * key count, but never less than
-	// one. If a key falls below its goal, it gets a sample rate of 1 and the
-	// extra available events get passed on down the line.
-	keysRemaining := len(tmpCounts)
-	var extra float64
-	for _, key := range keys {
-		count := float64(tmpCounts[key])
-		// take the max of 1 or my log10 share of the total
-		goalForKey := math.Max(1, math.Log10(count)*goalRatio)
-
-		// take this key's share of the extra and pass the rest along
-		extraForKey := extra / float64(keysRemaining)
-		goalForKey += extraForKey
-		extra -= extraForKey
-		keysRemaining--
-		if count <= goalForKey {
-			// there are fewer samples than the allotted number for this key. set
-			// sample rate to 1 and redistribute the unused slots for future keys
-			newSavedSampleRates[key] = 1
-			extra += goalForKey - count
-		} else {
-			// there are more samples than the allotted number. Sample this key enough
-			// to knock it under the limit (aka round up)
-			rate := math.Ceil(count / goalForKey)
-			// if counts are <= 1 we can get values for goalForKey that are +Inf
-			// and subsequent division ends up with NaN. If that's the case,
-			// fall back to 1
-			if math.IsNaN(rate) {
-				newSavedSampleRates[key] = 1
-			} else {
-				newSavedSampleRates[key] = int(rate)
-			}
-			extra += goalForKey - (count / float64(newSavedSampleRates[key]))
-		}
-	}
+	newSavedSampleRates = calculateSampleRates(goalRatio, tmpCounts)
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	a.savedSampleRates = newSavedSampleRates
@@ -203,10 +158,10 @@ func (a *AvgSampleWithMin) GetSampleRateMulti(key string, count int) int {
 	if a.MaxKeys > 0 {
 		// If a key already exists, increment it. If not, but we're under the limit, store a new key
 		if _, found := a.currentCounts[key]; found || len(a.currentCounts) < a.MaxKeys {
-			a.currentCounts[key] += count
+			a.currentCounts[key] += float64(count)
 		}
 	} else {
-		a.currentCounts[key] += count
+		a.currentCounts[key] += float64(count)
 	}
 	if !a.haveData {
 		return a.GoalSampleRate

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -16,11 +16,11 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 		ClearFrequencySec: 30,
 	}
 	tsts := []struct {
-		inputSampleCount         map[string]int
+		inputSampleCount         map[string]float64
 		expectedSavedSampleRates map[string]int
 	}{
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   1,
 				"two":   1,
 				"three": 2,
@@ -46,7 +46,7 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   1,
 				"two":   1,
 				"three": 2,
@@ -70,7 +70,7 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   1,
 				"two":   1,
 				"three": 2,
@@ -86,7 +86,7 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one": 1,
 			},
 			map[string]int{
@@ -94,7 +94,7 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one": 8,
 			},
 			map[string]int{
@@ -102,7 +102,7 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one": 12000,
 			},
 			map[string]int{
@@ -110,7 +110,7 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   1000,
 				"two":   1000,
 				"three": 2000,
@@ -126,7 +126,7 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{
+			map[string]float64{
 				"one":   6000,
 				"two":   6000,
 				"three": 6000,
@@ -142,7 +142,7 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 			},
 		},
 		{
-			map[string]int{},
+			map[string]float64{},
 			map[string]int{},
 		},
 	}
@@ -157,19 +157,19 @@ func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 func TestAvgSampleWithMinGetSampleRateStartup(t *testing.T) {
 	a := &AvgSampleWithMin{
 		GoalSampleRate: 10,
-		currentCounts:  map[string]int{},
+		currentCounts:  map[string]float64{},
 	}
 	rate := a.GetSampleRate("key")
 	assert.Equal(t, rate, 10)
 	// and the counters still get bumped
-	assert.Equal(t, a.currentCounts["key"], 1)
+	assert.Equal(t, a.currentCounts["key"], 1.)
 }
 
 func TestAvgSampleWithMinGetSampleRate(t *testing.T) {
 	a := &AvgSampleWithMin{
 		haveData: true,
 	}
-	a.currentCounts = map[string]int{
+	a.currentCounts = map[string]float64{
 		"one": 5,
 		"two": 8,
 	}
@@ -181,7 +181,7 @@ func TestAvgSampleWithMinGetSampleRate(t *testing.T) {
 	tsts := []struct {
 		inputKey                   string
 		expectedSampleRate         int
-		expectedCurrentCountForKey int
+		expectedCurrentCountForKey float64
 	}{
 		{"one", 10, 6},
 		{"two", 1, 9},
@@ -201,7 +201,7 @@ func TestAvgSampleWithMinGetSampleRate(t *testing.T) {
 func TestAvgSampleWithMinRace(t *testing.T) {
 	a := &AvgSampleWithMin{
 		GoalSampleRate:   2,
-		currentCounts:    map[string]int{},
+		currentCounts:    map[string]float64{},
 		savedSampleRates: map[string]int{},
 		haveData:         true,
 	}
@@ -235,7 +235,7 @@ func TestAvgSampleWithMinMaxKeys(t *testing.T) {
 	a := &AvgSampleWithMin{
 		MaxKeys: 3,
 	}
-	a.currentCounts = map[string]int{
+	a.currentCounts = map[string]float64{
 		"one": 1,
 		"two": 1,
 	}
@@ -244,7 +244,7 @@ func TestAvgSampleWithMinMaxKeys(t *testing.T) {
 	// with MaxKeys 3, we are under the key limit, so three should get added
 	a.GetSampleRate("three")
 	assert.Equal(t, 3, len(a.currentCounts))
-	assert.Equal(t, 1, a.currentCounts["three"])
+	assert.Equal(t, 1., a.currentCounts["three"])
 	// Now we're at 3 keys - four should not be added
 	a.GetSampleRate("four")
 	assert.Equal(t, 3, len(a.currentCounts))
@@ -253,5 +253,5 @@ func TestAvgSampleWithMinMaxKeys(t *testing.T) {
 	// We should still support bumping counts for existing keys
 	a.GetSampleRate("one")
 	assert.Equal(t, 3, len(a.currentCounts))
-	assert.Equal(t, 2, a.currentCounts["one"])
+	assert.Equal(t, 2., a.currentCounts["one"])
 }

--- a/genericsampler_test.go
+++ b/genericsampler_test.go
@@ -8,16 +8,11 @@ import (
 	"github.com/honeycombio/dynsampler-go"
 )
 
-// we'll accept 2% slop
-func isCloseTo(want, got int) bool {
-	acceptableVariance := (want * 2) / 100
-	return got >= want-acceptableVariance && got <= want+acceptableVariance
-}
-
 // If given consistent data, the samplers very quickly settle to their target
-// rates, so this test specifically hands different samplers identical data each
-// time and expects them to find the right values quickly. This is a slightly
-// higher-level test that only depends on the public interface of samplers.
+// rates and we can expect exact results. This test specifically hands different
+// samplers identical data each time and expects them to find the right values
+// quickly. This is a slightly higher-level test that only depends on the public
+// interface of samplers.
 func TestGenericSamplerBehavior(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -98,7 +93,8 @@ func TestGenericSamplerBehavior(t *testing.T) {
 			s.Stop()
 
 			for k := 0; k < nkeys; k++ {
-				if !isCloseTo(tt.want[k], results[k]) {
+				// if !isCloseTo(tt.want[k], results[k]) {
+				if tt.want[k] != results[k] {
 					t.Errorf("results not close enough = for key %s (%d) want %d, got %d\n", keys[k], k, tt.want[k], results[k])
 				}
 			}

--- a/keyCalculation.go
+++ b/keyCalculation.go
@@ -1,0 +1,56 @@
+package dynsampler
+
+import (
+	"math"
+	"sort"
+)
+
+// This is an extraction of common calculation logic for all the key-based samplers.
+func calculateSampleRates(goalRatio float64, buckets map[string]float64) map[string]int {
+	// must go through the keys in a fixed order to prevent rounding from changing
+	// results
+	keys := make([]string, len(buckets))
+	var i int
+	for k := range buckets {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+
+	// goal number of events per key is goalRatio * key count, but never less than
+	// one. If a key falls below its goal, it gets a sample rate of 1 and the
+	// extra available events get passed on down the line.
+	newSampleRates := make(map[string]int)
+	keysRemaining := len(buckets)
+	var extra float64
+	for _, key := range keys {
+		count := math.Max(1, buckets[key])
+		// take the max of 1 or my log10 share of the total
+		goalForKey := math.Max(1, math.Log10(count)*goalRatio)
+		// take this key's share of the extra and pass the rest along
+		extraForKey := extra / float64(keysRemaining)
+		goalForKey += extraForKey
+		extra -= extraForKey
+		keysRemaining--
+		if count <= goalForKey {
+			// there are fewer samples than the allotted number for this key. set
+			// sample rate to 1 and redistribute the unused slots for future keys
+			newSampleRates[key] = 1
+			extra += goalForKey - count
+		} else {
+			// there are more samples than the allotted number. Sample this key enough
+			// to knock it under the limit (aka round up)
+			rate := math.Ceil(count / goalForKey)
+			// if counts are <= 1 we can get values for goalForKey that are +Inf
+			// and subsequent division ends up with NaN. If that's the case,
+			// fall back to 1
+			if math.IsNaN(rate) {
+				newSampleRates[key] = 1
+			} else {
+				newSampleRates[key] = int(rate)
+			}
+			extra += goalForKey - (count / float64(newSampleRates[key]))
+		}
+	}
+	return newSampleRates
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- In attempting to add a new kind of sampler, I noticed that several existing samplers used nearly identical code to handle the sample rate calculation. This unifies them (and the new sampler will also use it)

## Short description of the changes

- Pull out a `calculateSampleRates` function.
- Change some int calculations in samplers to floats. This has little practical effect since sample rates fit comfortably into a float. The EMA sampler needs floats, and while the other ones don't, this was the best solution. Alternatives were:
    - Make this function generic, but that would have required bumping the supported Go versions
    - Transform the int buckets to a temporary float bucket to pass to this function, but that would have required a second loop over what could potentially be thousands of keys in a map.
    - Pull out two common functions that are otherwise identical
- Fix tests to use floats.

