### PR TITLE
feat: Deprecate integer seconds and replace with time.Duration

### DIFF
--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -3,6 +3,7 @@ package dynsampler
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -19,8 +20,14 @@ import (
 // ClearFrequencySec and more frequent keys will have their sample rate
 // increased proportionally to wind up with the goal sample rate.
 type AvgSampleRate struct {
-	// ClearFrequencySec is how often the counters reset in seconds; default 30
+	// ClearFrequencySec is how often the counters reset in seconds; default 30.
+	// DEPRECATED -- use ClearFrequencyDuration.
 	ClearFrequencySec int
+
+	// ClearFrequencyDuration is how often the counters reset as a Duration.
+	// Note that either this or ClearFrequencySec can be specified, but not both.
+	// If neither one is set, the default is 30s.
+	ClearFrequencyDuration time.Duration
 
 	// GoalSampleRate is the average sample rate we're aiming for, across all
 	// events. Default 10
@@ -49,9 +56,18 @@ var _ Sampler = (*AvgSampleRate)(nil)
 
 func (a *AvgSampleRate) Start() error {
 	// apply defaults
-	if a.ClearFrequencySec == 0 {
-		a.ClearFrequencySec = 30
+	if a.ClearFrequencyDuration != 0 && a.ClearFrequencySec != 0 {
+		return fmt.Errorf("the ClearFrequencySec configuration value is deprecated; use only ClearFrequencyDuration")
 	}
+
+	if a.ClearFrequencyDuration == 0 && a.ClearFrequencySec == 0 {
+		a.ClearFrequencyDuration = 30 * time.Second
+	} else {
+		if a.ClearFrequencySec != 0 {
+			a.ClearFrequencyDuration = time.Duration(a.ClearFrequencySec) * time.Second
+		}
+	}
+
 	if a.GoalSampleRate == 0 {
 		a.GoalSampleRate = 10
 	}
@@ -66,7 +82,7 @@ func (a *AvgSampleRate) Start() error {
 
 	// spin up calculator
 	go func() {
-		ticker := time.NewTicker(time.Second * time.Duration(a.ClearFrequencySec))
+		ticker := time.NewTicker(a.ClearFrequencyDuration)
 		defer ticker.Stop()
 		for {
 			select {

--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -14,11 +14,11 @@ import (
 // the correct average. This method breaks down when total traffic is low
 // because it will be excessively sampled.
 //
-// Keys that occur only once within ClearFrequencySec will always have a sample
-// rate of 1. Keys that occur more frequently will be sampled on a logarithmic
-// curve. In other words, every key will be represented at least once per
-// ClearFrequencySec and more frequent keys will have their sample rate
-// increased proportionally to wind up with the goal sample rate.
+// Keys that occur only once within ClearFrequencyDuration will always have a
+// sample rate of 1. Keys that occur more frequently will be sampled on a
+// logarithmic curve. In other words, every key will be represented at least
+// once per ClearFrequencyDuration and more frequent keys will have their sample
+// rate increased proportionally to wind up with the goal sample rate.
 type AvgSampleRate struct {
 	// ClearFrequencySec is how often the counters reset in seconds; default 30.
 	// DEPRECATED -- use ClearFrequencyDuration.
@@ -34,7 +34,7 @@ type AvgSampleRate struct {
 	GoalSampleRate int
 
 	// MaxKeys, if greater than 0, limits the number of distinct keys used to build
-	// the sample rate map within the interval defined by `ClearFrequencySec`. Once
+	// the sample rate map within the interval defined by `ClearFrequencyDuration`. Once
 	// MaxKeys is reached, new keys will not be included in the sample rate map, but
 	// existing keys will continue to be be counted.
 	MaxKeys int

--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -20,8 +20,8 @@ import (
 // once per ClearFrequencyDuration and more frequent keys will have their sample
 // rate increased proportionally to wind up with the goal sample rate.
 type AvgSampleRate struct {
-	// ClearFrequencySec is how often the counters reset in seconds; default 30.
 	// DEPRECATED -- use ClearFrequencyDuration.
+	// ClearFrequencySec is how often the counters reset in seconds.
 	ClearFrequencySec int
 
 	// ClearFrequencyDuration is how often the counters reset as a Duration.

--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -410,3 +410,36 @@ func randomString(length int) string {
 	rand.Read(b)
 	return fmt.Sprintf("%x", b)
 }
+
+func TestAvgSampleRate_Start(t *testing.T) {
+	tests := []struct {
+		name                   string
+		ClearFrequencySec      int
+		ClearFrequencyDuration time.Duration
+		wantDuration           time.Duration
+		wantErr                bool
+	}{
+		{"sec only", 2, 0, 2 * time.Second, false},
+		{"dur only", 0, 1003 * time.Millisecond, 1003 * time.Millisecond, false},
+		{"default", 0, 0, 30 * time.Second, false},
+		{"both", 2, 2 * time.Second, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AvgSampleRate{
+				ClearFrequencySec:      tt.ClearFrequencySec,
+				ClearFrequencyDuration: tt.ClearFrequencyDuration,
+			}
+			err := a.Start()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AvgSampleRate error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				defer a.Stop()
+				if tt.wantDuration != a.ClearFrequencyDuration {
+					t.Errorf("AvgSampleRate duration mismatch = want %v, got %v", tt.wantDuration, a.ClearFrequencyDuration)
+				}
+			}
+		})
+	}
+}

--- a/avgsamplewithmin.go
+++ b/avgsamplewithmin.go
@@ -20,8 +20,8 @@ import (
 // ClearFrequencyDuration and more frequent keys will have their sample rate
 // increased proportionally to wind up with the goal sample rate.
 type AvgSampleWithMin struct {
-	// ClearFrequencySec is how often the counters reset in seconds; default 30.
 	// DEPRECATED -- use ClearFrequencyDuration.
+	// ClearFrequencySec is how often the counters reset in seconds.
 	ClearFrequencySec int
 
 	// ClearFrequencyDuration is how often the counters reset as a Duration.

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 	a := &AvgSampleWithMin{
-		GoalSampleRate:    20,
-		MinEventsPerSec:   50,
-		ClearFrequencySec: 30,
+		GoalSampleRate:         20,
+		MinEventsPerSec:        50,
+		ClearFrequencyDuration: 30 * time.Second,
 	}
 	tsts := []struct {
 		inputSampleCount         map[string]float64

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -278,12 +278,12 @@ func TestAvgSampleWithMin_Start(t *testing.T) {
 			}
 			err := a.Start()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("AvgSampleRate error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("AvgSampleWithMin error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if err == nil {
 				defer a.Stop()
 				if tt.wantDuration != a.ClearFrequencyDuration {
-					t.Errorf("AvgSampleRate duration mismatch = want %v, got %v", tt.wantDuration, a.ClearFrequencyDuration)
+					t.Errorf("AvgSampleWithMin duration mismatch = want %v, got %v", tt.wantDuration, a.ClearFrequencyDuration)
 				}
 			}
 		})

--- a/emasamplerate.go
+++ b/emasamplerate.go
@@ -29,12 +29,13 @@ import (
 // given window and more frequent keys will have their sample rate
 // increased proportionally to wind up with the goal sample rate.
 type EMASampleRate struct {
+	// DEPRECATED -- use AdjustmentIntervalDuration
 	// AdjustmentInterval defines how often (in seconds) we adjust the moving average from
 	// recent observations.
-	// DEPRECATED -- use AdjustmentIntervalDuration
 	AdjustmentInterval int
 
-	// AdjustmentIntervalDuration is how often the counters reset as a Duration.
+	// AdjustmentIntervalDuration is how often we adjust the moving average from
+	// recent observations.
 	// Note that either this or AdjustmentInterval can be specified, but not both.
 	// If neither one is set, the default is 15s.
 	AdjustmentIntervalDuration time.Duration

--- a/emasamplerate.go
+++ b/emasamplerate.go
@@ -3,6 +3,7 @@ package dynsampler
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -29,8 +30,14 @@ import (
 // increased proportionally to wind up with the goal sample rate.
 type EMASampleRate struct {
 	// AdjustmentInterval defines how often (in seconds) we adjust the moving average from
-	// recent observations. Default 15s
+	// recent observations.
+	// DEPRECATED -- use AdjustmentIntervalDuration
 	AdjustmentInterval int
+
+	// AdjustmentIntervalDuration is how often the counters reset as a Duration.
+	// Note that either this or AdjustmentInterval can be specified, but not both.
+	// If neither one is set, the default is 15s.
+	AdjustmentIntervalDuration time.Duration
 
 	// Weight is a value between (0, 1) indicating the weighting factor used to adjust
 	// the EMA. With larger values, newer data will influence the average more, and older
@@ -57,7 +64,7 @@ type EMASampleRate struct {
 
 	// BurstMultiple, if set, is multiplied by the sum of the running average of counts to define
 	// the burst detection threshold. If total counts observed for a given interval exceed the threshold
-	// EMA is updated immediately, rather than waiting on the AdjustmentInterval.
+	// EMA is updated immediately, rather than waiting on the AdjustmentIntervalDuration.
 	// Defaults to 2; negative value disables. With a default of 2, if your traffic suddenly doubles,
 	// burst detection will kick in.
 	BurstMultiple float64
@@ -92,9 +99,18 @@ var _ Sampler = (*EMASampleRate)(nil)
 
 func (e *EMASampleRate) Start() error {
 	// apply defaults
-	if e.AdjustmentInterval == 0 {
-		e.AdjustmentInterval = 15
+	if e.AdjustmentIntervalDuration != 0 && e.AdjustmentInterval != 0 {
+		return fmt.Errorf("the AdjustmentInterval configuration value is deprecated; use only AdjustmentIntervalDuration")
 	}
+
+	if e.AdjustmentIntervalDuration == 0 && e.AdjustmentInterval == 0 {
+		e.AdjustmentIntervalDuration = 15 * time.Second
+	} else {
+		if e.AdjustmentInterval != 0 {
+			e.AdjustmentIntervalDuration = time.Duration(e.AdjustmentInterval) * time.Second
+		}
+	}
+
 	if e.GoalSampleRate == 0 {
 		e.GoalSampleRate = 10
 	}
@@ -123,14 +139,14 @@ func (e *EMASampleRate) Start() error {
 	e.done = make(chan struct{})
 
 	go func() {
-		ticker := time.NewTicker(time.Second * time.Duration(e.AdjustmentInterval))
+		ticker := time.NewTicker(e.AdjustmentIntervalDuration)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-e.burstSignal:
 				// reset ticker when we get a burst
 				ticker.Stop()
-				ticker = time.NewTicker(time.Second * time.Duration(e.AdjustmentInterval))
+				ticker = time.NewTicker(e.AdjustmentIntervalDuration)
 				e.updateMaps()
 			case <-ticker.C:
 				e.updateMaps()

--- a/emasamplerate_test.go
+++ b/emasamplerate_test.go
@@ -294,7 +294,7 @@ func TestEMAAgesOutSmallValues(t *testing.T) {
 
 func TestEMABurstDetection(t *testing.T) {
 	// Set the adjustment interval very high so that we never run the regular interval
-	e := &EMASampleRate{AdjustmentInterval: 3600}
+	e := &EMASampleRate{AdjustmentIntervalDuration: 1 * time.Hour}
 	err := e.Start()
 	assert.Nil(t, err)
 
@@ -326,7 +326,7 @@ func TestEMABurstDetection(t *testing.T) {
 }
 
 func TestEMAUpdateMapsRace(t *testing.T) {
-	e := &EMASampleRate{AdjustmentInterval: 3600}
+	e := &EMASampleRate{AdjustmentIntervalDuration: 1 * time.Hour}
 	e.testSignalMapsDone = make(chan struct{}, 1000)
 	err := e.Start()
 	assert.Nil(t, err)

--- a/emasamplerate_test.go
+++ b/emasamplerate_test.go
@@ -500,3 +500,36 @@ func TestEMASampleRateMultiHitsTargetRate(t *testing.T) {
 		}
 	}
 }
+
+func TestEMASampleRate_Start(t *testing.T) {
+	tests := []struct {
+		name                       string
+		AdjustmentInterval         int
+		AdjustmentIntervalDuration time.Duration
+		wantDuration               time.Duration
+		wantErr                    bool
+	}{
+		{"sec only", 2, 0, 2 * time.Second, false},
+		{"dur only", 0, 1003 * time.Millisecond, 1003 * time.Millisecond, false},
+		{"default", 0, 0, 15 * time.Second, false},
+		{"both", 2, 2 * time.Second, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &EMASampleRate{
+				AdjustmentInterval:         tt.AdjustmentInterval,
+				AdjustmentIntervalDuration: tt.AdjustmentIntervalDuration,
+			}
+			err := a.Start()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EMASampleRate error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				defer a.Stop()
+				if tt.wantDuration != a.AdjustmentIntervalDuration {
+					t.Errorf("EMASampleRate duration mismatch = want %v, got %v", tt.wantDuration, a.AdjustmentIntervalDuration)
+				}
+			}
+		})
+	}
+}

--- a/genericsampler_test.go
+++ b/genericsampler_test.go
@@ -21,12 +21,12 @@ func TestGenericSamplerBehavior(t *testing.T) {
 	}{
 		{"AvgSampleRate",
 			&dynsampler.AvgSampleRate{
-				ClearFrequencySec: 1,
+				ClearFrequencyDuration: 1 * time.Second,
 			}, []int{1, 1, 1, 1, 2, 4, 9, 21},
 		},
 		{"AvgSampleWithMin",
 			&dynsampler.AvgSampleWithMin{
-				ClearFrequencySec: 1,
+				ClearFrequencyDuration: 1 * time.Second,
 			}, []int{1, 1, 1, 1, 1, 2, 4, 9, 21},
 		},
 		{"EMASampler",
@@ -36,18 +36,18 @@ func TestGenericSamplerBehavior(t *testing.T) {
 		},
 		{"OnlyOnce",
 			&dynsampler.OnlyOnce{
-				ClearFrequencySec: 1,
+				ClearFrequencyDuration: 1 * time.Second,
 			}, []int{1, 1, 1, 1, 1, 1, 1, 1},
 		},
 		{"PerKeyThroughput",
 			&dynsampler.PerKeyThroughput{
-				ClearFrequencySec: 1,
+				ClearFrequencyDuration: 1 * time.Second,
 			}, []int{1, 1, 1, 2, 8, 24, 72, 218},
 		},
 		{"TotalThroughput",
 			&dynsampler.TotalThroughput{
-				ClearFrequencySec:    1,
-				GoalThroughputPerSec: 5,
+				ClearFrequencyDuration: 1 * time.Second,
+				GoalThroughputPerSec:   5,
 			}, []int{1, 3, 9, 27, 81, 243, 729, 2187},
 		},
 		{"WindowedThroughput",

--- a/onlyonce.go
+++ b/onlyonce.go
@@ -1,6 +1,7 @@
 package dynsampler
 
 import (
+	"fmt"
 	"sync"
 	"time"
 )
@@ -8,8 +9,8 @@ import (
 // OnlyOnce implements Sampler and returns a sample rate of 1 the first time a
 // key is seen and 1,000,000,000 every subsequent time.  Essentially, this means
 // that every key will be reported the first time it's seen during each
-// ClearFrequencySec and never again.  Set ClearFrequencySec to -1 to report
-// each key only once for the life of the process.
+// ClearFrequencySec and never again.  Set ClearFrequencySec to a negative
+// number to report each key only once for the life of the process.
 //
 // (Note that it's not guaranteed that each key will be reported exactly once,
 // just that the first seen event will be reported and subsequent events are
@@ -20,8 +21,14 @@ import (
 // the first one is important but every subsequent one just repeats the same
 // information.
 type OnlyOnce struct {
-	// ClearFrequencySec is how often the counters reset in seconds; default 30
+	// DEPRECATED -- use ClearFrequencyDuration.
+	// ClearFrequencySec is how often the counters reset in seconds.
 	ClearFrequencySec int
+
+	// ClearFrequencyDuration is how often the counters reset as a Duration.
+	// Note that either this or ClearFrequencySec can be specified, but not both.
+	// If neither one is set, the default is 30s.
+	ClearFrequencyDuration time.Duration
 
 	seen map[string]bool
 	done chan struct{}
@@ -34,19 +41,29 @@ var _ Sampler = (*OnlyOnce)(nil)
 
 // Start initializes the static dynsampler
 func (o *OnlyOnce) Start() error {
-	//
-	if o.ClearFrequencySec == -1 {
+	if o.ClearFrequencyDuration != 0 && o.ClearFrequencySec != 0 {
+		return fmt.Errorf("the ClearFrequencySec configuration value is deprecated; use only ClearFrequencyDuration")
+	}
+
+	if o.ClearFrequencyDuration == 0 && o.ClearFrequencySec == 0 {
+		o.ClearFrequencyDuration = 30 * time.Second
+	} else {
+		if o.ClearFrequencySec != 0 {
+			o.ClearFrequencyDuration = time.Duration(o.ClearFrequencySec) * time.Second
+		}
+	}
+
+	// if it's negative, we don't even start something
+	if o.ClearFrequencyDuration < 0 {
 		return nil
 	}
-	if o.ClearFrequencySec == 0 {
-		o.ClearFrequencySec = 30
-	}
+
 	o.seen = make(map[string]bool)
 	o.done = make(chan struct{})
 
 	// spin up calculator
 	go func() {
-		ticker := time.NewTicker(time.Second * time.Duration(o.ClearFrequencySec))
+		ticker := time.NewTicker(o.ClearFrequencyDuration)
 		defer ticker.Stop()
 		for {
 			select {
@@ -61,7 +78,9 @@ func (o *OnlyOnce) Start() error {
 }
 
 func (o *OnlyOnce) Stop() error {
-	close(o.done)
+	if o.done != nil {
+		close(o.done)
+	}
 	return nil
 }
 

--- a/onlyonce_test.go
+++ b/onlyonce_test.go
@@ -3,13 +3,14 @@ package dynsampler
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestOnlyOnceUpdateMaps(t *testing.T) {
 	o := &OnlyOnce{
-		ClearFrequencySec: 30,
+		ClearFrequencyDuration: 30 * time.Second,
 	}
 	tsts := []struct {
 		inputSeen    map[string]bool
@@ -60,5 +61,40 @@ func TestOnlyOnceGetSampleRate(t *testing.T) {
 		rate := o.GetSampleRate(tst.inputKey)
 		assert.Equal(t, rate, tst.expectedSampleRate)
 		assert.Equal(t, o.seen[tst.inputKey], tst.expectedCurrentCountForKeyAfter)
+	}
+}
+
+func TestOnlyOnce_Start(t *testing.T) {
+	tests := []struct {
+		name                   string
+		ClearFrequencySec      int
+		ClearFrequencyDuration time.Duration
+		wantDuration           time.Duration
+		wantErr                bool
+	}{
+		{"sec only", 2, 0, 2 * time.Second, false},
+		{"dur only", 0, 1003 * time.Millisecond, 1003 * time.Millisecond, false},
+		{"default", 0, 0, 30 * time.Second, false},
+		{"both", 2, 2 * time.Second, 0, true},
+		{"negative sec", -1, 0, -1 * time.Second, false},
+		{"negative dur", 0, -1 * time.Second, -1 * time.Second, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &OnlyOnce{
+				ClearFrequencySec:      tt.ClearFrequencySec,
+				ClearFrequencyDuration: tt.ClearFrequencyDuration,
+			}
+			err := a.Start()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OnlyOnce error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				defer a.Stop()
+				if tt.wantDuration != a.ClearFrequencyDuration {
+					t.Errorf("OnlyOnce duration mismatch = want %v, got %v", tt.wantDuration, a.ClearFrequencyDuration)
+				}
+			}
+		})
 	}
 }

--- a/perkeythroughput_test.go
+++ b/perkeythroughput_test.go
@@ -5,13 +5,14 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPerKeyThroughputUpdateMaps(t *testing.T) {
 	p := &PerKeyThroughput{
-		ClearFrequencySec:      30,
+		ClearFrequencyDuration: 30 * time.Second,
 		PerKeyThroughputPerSec: 5,
 	}
 	tsts := []struct {
@@ -239,4 +240,37 @@ func TestPerKeyThroughputMaxKeys(t *testing.T) {
 	p.GetSampleRate("one")
 	assert.Equal(t, 3, len(p.currentCounts))
 	assert.Equal(t, 2, p.currentCounts["one"])
+}
+
+func TestPerKeyThroughput_Start(t *testing.T) {
+	tests := []struct {
+		name                   string
+		ClearFrequencySec      int
+		ClearFrequencyDuration time.Duration
+		wantDuration           time.Duration
+		wantErr                bool
+	}{
+		{"sec only", 2, 0, 2 * time.Second, false},
+		{"dur only", 0, 1003 * time.Millisecond, 1003 * time.Millisecond, false},
+		{"default", 0, 0, 30 * time.Second, false},
+		{"both", 2, 2 * time.Second, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &PerKeyThroughput{
+				ClearFrequencySec:      tt.ClearFrequencySec,
+				ClearFrequencyDuration: tt.ClearFrequencyDuration,
+			}
+			err := a.Start()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PerKeyThroughput error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil {
+				defer a.Stop()
+				if tt.wantDuration != a.ClearFrequencyDuration {
+					t.Errorf("PerKeyThroughput duration mismatch = want %v, got %v", tt.wantDuration, a.ClearFrequencyDuration)
+				}
+			}
+		})
+	}
 }

--- a/totalthroughput.go
+++ b/totalthroughput.go
@@ -1,6 +1,7 @@
 package dynsampler
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -13,15 +14,21 @@ import (
 // for making sure each server sends roughly the same volume of content to
 // Honeycomb. It performs poorly when the active keyspace is very large.
 //
-// GoalThroughputSec * ClearFrequencySec defines the upper limit of the number
-// of keys that can be reported and stay under the goal, but with that many
-// keys, you'll only get one event per key per ClearFrequencySec, which is very
-// coarse. You should aim for at least 1 event per key per sec to 1 event per
-// key per 10sec to get reasonable data. In other words, the number of active
-// keys should be less than 10*GoalThroughputSec.
+// GoalThroughputSec * ClearFrequencyDuration (in seconds) defines the upper
+// limit of the number of keys that can be reported and stay under the goal, but
+// with that many keys, you'll only get one event per key per ClearFrequencySec,
+// which is very coarse. You should aim for at least 1 event per key per sec to
+// 1 event per key per 10sec to get reasonable data. In other words, the number
+// of active keys should be less than 10*GoalThroughputSec.
 type TotalThroughput struct {
-	// ClearFrequency is how often the counters reset in seconds; default 30
+	// DEPRECATED -- use ClearFrequencyDuration.
+	// ClearFrequencySec is how often the counters reset in seconds.
 	ClearFrequencySec int
+
+	// ClearFrequencyDuration is how often the counters reset as a Duration.
+	// Note that either this or ClearFrequencySec can be specified, but not both.
+	// If neither one is set, the default is 30s.
+	ClearFrequencyDuration time.Duration
 
 	// GoalThroughputPerSec is the target number of events to send per second.
 	// Sample rates are generated to squash the total throughput down to match the
@@ -46,9 +53,18 @@ var _ Sampler = (*TotalThroughput)(nil)
 
 func (t *TotalThroughput) Start() error {
 	// apply defaults
-	if t.ClearFrequencySec == 0 {
-		t.ClearFrequencySec = 30
+	if t.ClearFrequencyDuration != 0 && t.ClearFrequencySec != 0 {
+		return fmt.Errorf("the ClearFrequencySec configuration value is deprecated; use only ClearFrequencyDuration")
 	}
+
+	if t.ClearFrequencyDuration == 0 && t.ClearFrequencySec == 0 {
+		t.ClearFrequencyDuration = 30 * time.Second
+	} else {
+		if t.ClearFrequencySec != 0 {
+			t.ClearFrequencyDuration = time.Duration(t.ClearFrequencySec) * time.Second
+		}
+	}
+
 	if t.GoalThroughputPerSec == 0 {
 		t.GoalThroughputPerSec = 100
 	}
@@ -60,7 +76,7 @@ func (t *TotalThroughput) Start() error {
 
 	// spin up calculator
 	go func() {
-		ticker := time.NewTicker(time.Second * time.Duration(t.ClearFrequencySec))
+		ticker := time.NewTicker(t.ClearFrequencyDuration)
 		defer ticker.Stop()
 		for {
 			select {
@@ -96,10 +112,10 @@ func (t *TotalThroughput) updateMaps() {
 		t.savedSampleRates = make(map[string]int)
 		return
 	}
-	// figure out our target throughput per key over ClearFrequencySec
-	totalGoalThroughput := t.GoalThroughputPerSec * t.ClearFrequencySec
+	// figure out our target throughput per key over ClearFrequencyDuration
+	totalGoalThroughput := float64(t.GoalThroughputPerSec) * t.ClearFrequencyDuration.Seconds()
 	// floor the throughput but min should be 1 event per bucket per time period
-	throughputPerKey := int(math.Max(1, float64(totalGoalThroughput)/float64(numKeys)))
+	throughputPerKey := int(math.Max(1, totalGoalThroughput/float64(numKeys)))
 	// for each key, calculate sample rate by dividing counted events by the
 	// desired number of events
 	newSavedSampleRates := make(map[string]int)


### PR DESCRIPTION
## Which problem is this PR solving?

- Some samplers were using integer seconds rather than time.Duration for specifying intervals. Durations are the right answer, especially for configurations since they can be specified with fairly natural strings like `1m30s` or `300ms`.

## Short description of the changes

- Deprecate things like ClearFrequencySec
- Add ClearFrequencyDuration and the logic so that both cannot be specified, and that if *Sec is specified, then it's converted to a Duration in the proper units
- Fix the math to use durations
- Write tests to make sure it all works

Fixes #56.
