### PR TITLE
feat: Add metrics counter retrieval

### DIFF
--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -217,9 +217,9 @@ func (a *AvgSampleRate) GetMetrics(prefix string) map[string]int64 {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count": a.requestCount,
-		prefix + "_event_count":   a.eventCount,
-		prefix + "_keyspace_size": int64(len(a.currentCounts)),
+		prefix + "request_count": a.requestCount,
+		prefix + "event_count":   a.eventCount,
+		prefix + "keyspace_size": int64(len(a.currentCounts)),
 	}
 	return mets
 }

--- a/avgsamplewithmin.go
+++ b/avgsamplewithmin.go
@@ -207,9 +207,9 @@ func (a *AvgSampleWithMin) GetMetrics(prefix string) map[string]int64 {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count": a.requestCount,
-		prefix + "_event_count":   a.eventCount,
-		prefix + "_keyspace_size": int64(len(a.currentCounts)),
+		prefix + "request_count": a.requestCount,
+		prefix + "event_count":   a.eventCount,
+		prefix + "keyspace_size": int64(len(a.currentCounts)),
 	}
 	return mets
 }

--- a/avgsamplewithmin.go
+++ b/avgsamplewithmin.go
@@ -53,6 +53,10 @@ type AvgSampleWithMin struct {
 	done     chan struct{}
 
 	lock sync.Mutex
+
+	// metrics
+	requestCount int64
+	eventCount   int64
 }
 
 // Ensure we implement the sampler interface
@@ -168,6 +172,9 @@ func (a *AvgSampleWithMin) GetSampleRateMulti(key string, count int) int {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 
+	a.requestCount++
+	a.eventCount += int64(count)
+
 	// Enforce MaxKeys limit on the size of the map
 	if a.MaxKeys > 0 {
 		// If a key already exists, increment it. If not, but we're under the limit, store a new key
@@ -194,4 +201,15 @@ func (a *AvgSampleWithMin) SaveState() ([]byte, error) {
 // LoadState is not implemented
 func (a *AvgSampleWithMin) LoadState(state []byte) error {
 	return nil
+}
+
+func (a *AvgSampleWithMin) GetMetrics(prefix string) map[string]int64 {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	mets := map[string]int64{
+		prefix + "_request_count": a.requestCount,
+		prefix + "_event_count":   a.eventCount,
+		prefix + "_keyspace_size": int64(len(a.currentCounts)),
+	}
+	return mets
 }

--- a/dynsampler.go
+++ b/dynsampler.go
@@ -35,4 +35,10 @@ type Sampler interface {
 	// LoadState accepts a byte array containing the serialized, previous state of the sampler
 	// implementation. It should be called before `Start`.
 	LoadState([]byte) error
+
+	// GetMetrics returns a map of metrics about the sampler's performance.
+	// All values are returned as int64; counters are cumulative and the names
+	// always end with "_count", while gauges are instantaneous with no particular naming convention.
+	// All names are prefixed with the given string.
+	GetMetrics(prefix string) map[string]int64
 }

--- a/emasamplerate.go
+++ b/emasamplerate.go
@@ -361,11 +361,11 @@ func (e *EMASampleRate) GetMetrics(prefix string) map[string]int64 {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count":  e.requestCount,
-		prefix + "_event_count":    e.eventCount,
-		prefix + "_burst_count":    e.burstCount,
-		prefix + "_interval_count": int64(e.intervalCount),
-		prefix + "_keyspace_size":  int64(len(e.currentCounts)),
+		prefix + "request_count":  e.requestCount,
+		prefix + "event_count":    e.eventCount,
+		prefix + "burst_count":    e.burstCount,
+		prefix + "interval_count": int64(e.intervalCount),
+		prefix + "keyspace_size":  int64(len(e.currentCounts)),
 	}
 	return mets
 }

--- a/emasamplerate.go
+++ b/emasamplerate.go
@@ -93,6 +93,11 @@ type EMASampleRate struct {
 
 	// used only in tests
 	testSignalMapsDone chan struct{}
+
+	// metrics
+	requestCount int64
+	eventCount   int64
+	burstCount   int64
 }
 
 // Ensure we implement the sampler interface
@@ -238,6 +243,9 @@ func (e *EMASampleRate) GetSampleRateMulti(key string, count int) int {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
+	e.requestCount++
+	e.eventCount += int64(count)
+
 	// Enforce MaxKeys limit on the size of the map
 	if e.MaxKeys > 0 {
 		// If a key already exists, increment it. If not, but we're under the limit, store a new key
@@ -254,6 +262,7 @@ func (e *EMASampleRate) GetSampleRateMulti(key string, count int) int {
 	if e.burstThreshold > 0 && e.currentBurstSum >= e.burstThreshold && e.intervalCount >= e.BurstDetectionDelay {
 		// reset the burst sum to prevent additional burst updates from occurring while updateMaps is running
 		e.currentBurstSum = 0
+		e.burstCount++
 		// send but don't block - consuming is blocked on updateMaps, which takes the same lock we're holding
 		select {
 		case e.burstSignal <- struct{}{}:
@@ -346,6 +355,19 @@ func (e *EMASampleRate) LoadState(state []byte) error {
 	e.haveData = true
 
 	return nil
+}
+
+func (e *EMASampleRate) GetMetrics(prefix string) map[string]int64 {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	mets := map[string]int64{
+		prefix + "_request_count":  e.requestCount,
+		prefix + "_event_count":    e.eventCount,
+		prefix + "_burst_count":    e.burstCount,
+		prefix + "_interval_count": int64(e.intervalCount),
+		prefix + "_keyspace_size":  int64(len(e.currentCounts)),
+	}
+	return mets
 }
 
 func adjustAverage(oldAvg, value float64, alpha float64) float64 {

--- a/emathroughput.go
+++ b/emathroughput.go
@@ -99,6 +99,11 @@ type EMAThroughput struct {
 
 	// used only in tests
 	testSignalMapsDone chan struct{}
+
+	// metrics
+	requestCount int64
+	eventCount   int64
+	burstCount   int64
 }
 
 // Ensure we implement the sampler interface
@@ -249,6 +254,9 @@ func (e *EMAThroughput) GetSampleRateMulti(key string, count int) int {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
+	e.requestCount++
+	e.eventCount += int64(count)
+
 	// Enforce MaxKeys limit on the size of the map
 	if e.MaxKeys > 0 {
 		// If a key already exists, increment it. If not, but we're under the limit, store a new key
@@ -265,6 +273,7 @@ func (e *EMAThroughput) GetSampleRateMulti(key string, count int) int {
 	if e.burstThreshold > 0 && e.currentBurstSum >= e.burstThreshold && e.intervalCount >= e.BurstDetectionDelay {
 		// reset the burst sum to prevent additional burst updates from occurring while updateMaps is running
 		e.currentBurstSum = 0
+		e.burstCount++
 		// send but don't block - consuming is blocked on updateMaps, which takes the same lock we're holding
 		select {
 		case e.burstSignal <- struct{}{}:
@@ -357,4 +366,17 @@ func (e *EMAThroughput) LoadState(state []byte) error {
 	e.haveData = true
 
 	return nil
+}
+
+func (e *EMAThroughput) GetMetrics(prefix string) map[string]int64 {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	mets := map[string]int64{
+		prefix + "_request_count":  e.requestCount,
+		prefix + "_event_count":    e.eventCount,
+		prefix + "_burst_count":    e.burstCount,
+		prefix + "_interval_count": int64(e.intervalCount),
+		prefix + "_keyspace_size":  int64(len(e.currentCounts)),
+	}
+	return mets
 }

--- a/emathroughput.go
+++ b/emathroughput.go
@@ -372,11 +372,11 @@ func (e *EMAThroughput) GetMetrics(prefix string) map[string]int64 {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count":  e.requestCount,
-		prefix + "_event_count":    e.eventCount,
-		prefix + "_burst_count":    e.burstCount,
-		prefix + "_interval_count": int64(e.intervalCount),
-		prefix + "_keyspace_size":  int64(len(e.currentCounts)),
+		prefix + "request_count":  e.requestCount,
+		prefix + "event_count":    e.eventCount,
+		prefix + "burst_count":    e.burstCount,
+		prefix + "interval_count": int64(e.intervalCount),
+		prefix + "keyspace_size":  int64(len(e.currentCounts)),
 	}
 	return mets
 }

--- a/onlyonce.go
+++ b/onlyonce.go
@@ -127,9 +127,9 @@ func (o *OnlyOnce) GetMetrics(prefix string) map[string]int64 {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count": o.requestCount,
-		prefix + "_event_count":   o.eventCount,
-		prefix + "_keyspace_size": int64(len(o.seen)),
+		prefix + "request_count": o.requestCount,
+		prefix + "event_count":   o.eventCount,
+		prefix + "keyspace_size": int64(len(o.seen)),
 	}
 	return mets
 }

--- a/onlyonce.go
+++ b/onlyonce.go
@@ -33,6 +33,10 @@ type OnlyOnce struct {
 	seen map[string]bool
 	done chan struct{}
 
+	// metrics
+	requestCount int64
+	eventCount   int64
+
 	lock sync.Mutex
 }
 
@@ -99,6 +103,9 @@ func (o *OnlyOnce) GetSampleRate(key string) int {
 func (o *OnlyOnce) GetSampleRateMulti(key string, count int) int {
 	o.lock.Lock()
 	defer o.lock.Unlock()
+	o.requestCount++
+	o.eventCount += int64(count)
+
 	if _, found := o.seen[key]; found {
 		return 1000000000
 	}
@@ -114,4 +121,15 @@ func (o *OnlyOnce) SaveState() ([]byte, error) {
 // LoadState is not implemented
 func (o *OnlyOnce) LoadState(state []byte) error {
 	return nil
+}
+
+func (o *OnlyOnce) GetMetrics(prefix string) map[string]int64 {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	mets := map[string]int64{
+		prefix + "_request_count": o.requestCount,
+		prefix + "_event_count":   o.eventCount,
+		prefix + "_keyspace_size": int64(len(o.seen)),
+	}
+	return mets
 }

--- a/perkeythroughput.go
+++ b/perkeythroughput.go
@@ -166,9 +166,9 @@ func (p *PerKeyThroughput) GetMetrics(prefix string) map[string]int64 {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count": p.requestCount,
-		prefix + "_event_count":   p.eventCount,
-		prefix + "_keyspace_size": int64(len(p.currentCounts)),
+		prefix + "request_count": p.requestCount,
+		prefix + "event_count":   p.eventCount,
+		prefix + "keyspace_size": int64(len(p.currentCounts)),
 	}
 	return mets
 }

--- a/static.go
+++ b/static.go
@@ -67,9 +67,9 @@ func (s *Static) GetMetrics(prefix string) map[string]int64 {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count": s.requestCount,
-		prefix + "_event_count":   s.eventCount,
-		prefix + "_keyspace_size": int64(len(s.Rates)),
+		prefix + "request_count": s.requestCount,
+		prefix + "event_count":   s.eventCount,
+		prefix + "keyspace_size": int64(len(s.Rates)),
 	}
 	return mets
 }

--- a/static.go
+++ b/static.go
@@ -1,5 +1,7 @@
 package dynsampler
 
+import "sync"
+
 // Static implements Sampler with a static mapping for sample rates. This is
 // useful if you have a known set of keys that you want to sample at specific
 // rates and apply a default to everything else.
@@ -8,6 +10,12 @@ type Static struct {
 	Rates map[string]int
 	// Default is the value to use if the key is not whitelisted in Rates
 	Default int
+
+	lock sync.Mutex
+
+	// metrics
+	requestCount int64
+	eventCount   int64
 }
 
 // Ensure we implement the sampler interface
@@ -34,6 +42,11 @@ func (s *Static) GetSampleRate(key string) int {
 // GetSampleRateMulti takes a key representing count spans and returns the
 // appropriate sample rate for that key.
 func (s *Static) GetSampleRateMulti(key string, count int) int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.requestCount++
+	s.eventCount += int64(count)
 	if rate, found := s.Rates[key]; found {
 		return rate
 	}
@@ -48,4 +61,15 @@ func (s *Static) SaveState() ([]byte, error) {
 // LoadState is not implemented
 func (s *Static) LoadState(state []byte) error {
 	return nil
+}
+
+func (s *Static) GetMetrics(prefix string) map[string]int64 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	mets := map[string]int64{
+		prefix + "_request_count": s.requestCount,
+		prefix + "_event_count":   s.eventCount,
+		prefix + "_keyspace_size": int64(len(s.Rates)),
+	}
+	return mets
 }

--- a/totalthroughput.go
+++ b/totalthroughput.go
@@ -175,9 +175,9 @@ func (t *TotalThroughput) GetMetrics(prefix string) map[string]int64 {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count": t.requestCount,
-		prefix + "_event_count":   t.eventCount,
-		prefix + "_keyspace_size": int64(len(t.currentCounts)),
+		prefix + "request_count": t.requestCount,
+		prefix + "event_count":   t.eventCount,
+		prefix + "keyspace_size": int64(len(t.currentCounts)),
 	}
 	return mets
 }

--- a/windowedthroughput.go
+++ b/windowedthroughput.go
@@ -219,9 +219,9 @@ func (t *WindowedThroughput) GetMetrics(prefix string) map[string]int64 {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	mets := map[string]int64{
-		prefix + "_request_count": t.requestCount,
-		prefix + "_event_count":   t.eventCount,
-		prefix + "_keyspace_size": int64(t.numKeys),
+		prefix + "request_count": t.requestCount,
+		prefix + "event_count":   t.eventCount,
+		prefix + "keyspace_size": int64(t.numKeys),
 	}
 	return mets
 }

--- a/windowedthroughput.go
+++ b/windowedthroughput.go
@@ -56,6 +56,11 @@ type WindowedThroughput struct {
 	indexGenerator IndexGenerator
 
 	lock sync.Mutex
+
+	// metrics
+	requestCount int64
+	eventCount   int64
+	numKeys      int
 }
 
 // Ensure we implement the sampler interface
@@ -146,8 +151,8 @@ func (t *WindowedThroughput) updateMaps() {
 
 	// Apply the same aggregation algorithm as total throughput
 	// Short circuit if no traffic
-	numKeys := len(aggregateCounts)
-	if numKeys == 0 {
+	t.numKeys = len(aggregateCounts)
+	if t.numKeys == 0 {
 		// no traffic during the last period.
 		t.lock.Lock()
 		defer t.lock.Unlock()
@@ -157,7 +162,7 @@ func (t *WindowedThroughput) updateMaps() {
 	// figure out our target throughput per key over the lookback window.
 	totalGoalThroughput := t.GoalThroughputPerSec * t.LookbackFrequencyDuration.Seconds()
 	// floor the throughput but min should be 1 event per bucket per time period
-	throughputPerKey := math.Max(1, float64(totalGoalThroughput)/float64(numKeys))
+	throughputPerKey := math.Max(1, float64(totalGoalThroughput)/float64(t.numKeys))
 	// for each key, calculate sample rate by dividing counted events by the
 	// desired number of events
 	newSavedSampleRates := make(map[string]int)
@@ -180,6 +185,9 @@ func (t *WindowedThroughput) GetSampleRate(key string) int {
 // GetSampleRateMulti takes a key representing count spans and returns the
 // appropriate sample rate for that key.
 func (t *WindowedThroughput) GetSampleRateMulti(key string, count int) int {
+	t.requestCount++
+	t.eventCount += int64(count)
+
 	// Insert the new key into the map.
 	current := t.indexGenerator.GetCurrentIndex()
 	err := t.countList.IncrementKey(key, current, count)
@@ -205,4 +213,15 @@ func (t *WindowedThroughput) SaveState() ([]byte, error) {
 // LoadState is not implemented
 func (t *WindowedThroughput) LoadState(state []byte) error {
 	return nil
+}
+
+func (t *WindowedThroughput) GetMetrics(prefix string) map[string]int64 {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	mets := map[string]int64{
+		prefix + "_request_count": t.requestCount,
+		prefix + "_event_count":   t.eventCount,
+		prefix + "_keyspace_size": int64(t.numKeys),
+	}
+	return mets
 }


### PR DESCRIPTION
## Which problem is this PR solving?

To date, the samplers have had no way of getting any metrics from them, which has sometimes made it hard to support. This adds a simple GetMetrics call that retrieves a map of named metrics on request. 

GetMetrics returns a map of metrics about the sampler's performance. All values are returned as int64; counters are cumulative and the names always end with "_count", while gauges are instantaneous with no particular naming convention. All names are prefixed with the string passed in.

## Short description of the changes

- Add GetMetrics function to Sampler interface and all samplers

