### PR TITLE
fix: Small adjustment to throughput samplers

### DIFF
--- a/totalthroughput.go
+++ b/totalthroughput.go
@@ -116,8 +116,8 @@ func (t *TotalThroughput) updateMaps() {
 	}
 	// figure out our target throughput per key over ClearFrequencyDuration
 	totalGoalThroughput := float64(t.GoalThroughputPerSec) * t.ClearFrequencyDuration.Seconds()
-	// floor the throughput but min should be 1 event per bucket per time period
-	throughputPerKey := int(math.Max(1, totalGoalThroughput/float64(numKeys)))
+	// split the total throughput equally across the number of keys.
+	throughputPerKey := float64(totalGoalThroughput) / float64(numKeys)
 	// for each key, calculate sample rate by dividing counted events by the
 	// desired number of events
 	newSavedSampleRates := make(map[string]int)

--- a/windowedthroughput.go
+++ b/windowedthroughput.go
@@ -161,8 +161,8 @@ func (t *WindowedThroughput) updateMaps() {
 	}
 	// figure out our target throughput per key over the lookback window.
 	totalGoalThroughput := t.GoalThroughputPerSec * t.LookbackFrequencyDuration.Seconds()
-	// floor the throughput but min should be 1 event per bucket per time period
-	throughputPerKey := math.Max(1, float64(totalGoalThroughput)/float64(t.numKeys))
+	// split the total throughput equally across the number of keys.
+	throughputPerKey := float64(totalGoalThroughput) / float64(t.numKeys)
 	// for each key, calculate sample rate by dividing counted events by the
 	// desired number of events
 	newSavedSampleRates := make(map[string]int)


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

We heavily rely on throughput samplers at Stripe. We run a pretty big Refinery fleet here, ~80 - 100 instances, which means our _per instance_ sampling throughput target is pretty low. We're quickly running into cases where `numKeys` exceeds the the `totalGoalThroughput`, which results in our sampler over sampling at times.

Removing the floor allows the samplers to compute this case more accurately. 

## Short description of the changes

Removed `math.floor(...)`, essentially allows per key throughput to be less than 1.

## Testing

We've tested this sampler change in QA and prod, and it worked great!

Our target throughput in prod is around ~120 traces / second. Before the change, our effective sampling rate was ~270 traces / second. 

<img width="933" alt="Screenshot 2023-10-12 at 2 56 28 PM" src="https://github.com/honeycombio/dynsampler-go/assets/4894854/8562071b-cf6f-495e-a319-761f0b2de566">