### PR TITLE
perf: pre-compute metric keys

### DIFF
--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -51,8 +51,12 @@ type AvgSampleRate struct {
 	lock sync.Mutex
 
 	// metrics
-	requestCount int64
-	eventCount   int64
+	requestCount    int64
+	eventCount      int64
+	prefix          string
+	requestCountKey string
+	eventCountKey   string
+	keyspaceSizeKey string
 }
 
 // Ensure we implement the sampler interface
@@ -216,10 +220,22 @@ func (a *AvgSampleRate) LoadState(state []byte) error {
 func (a *AvgSampleRate) GetMetrics(prefix string) map[string]int64 {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	mets := map[string]int64{
-		prefix + "request_count": a.requestCount,
-		prefix + "event_count":   a.eventCount,
-		prefix + "keyspace_size": int64(len(a.currentCounts)),
+
+	if a.prefix == "" {
+		a.prefix = prefix
+		a.requestCountKey = a.prefix + requestCountSuffix
+		a.eventCountKey = a.prefix + eventCountSuffix
+		a.keyspaceSizeKey = a.prefix + keyspaceSizeSuffix
 	}
-	return mets
+
+	// If the prefix is set but does not match with the current prefix, return nil
+	if a.prefix != prefix {
+		return nil
+	}
+
+	return map[string]int64{
+		a.requestCountKey: a.requestCount,
+		a.eventCountKey:   a.eventCount,
+		a.keyspaceSizeKey: int64(len(a.currentCounts)),
+	}
 }

--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -443,3 +443,122 @@ func TestAvgSampleRate_Start(t *testing.T) {
 		})
 	}
 }
+
+func TestAvgSampleRateGetMetrics(t *testing.T) {
+	tests := []struct {
+		name           string
+		prefix         string
+		requestCount   int64
+		eventCount     int64
+		currentCounts  map[string]float64
+		existingPrefix string
+		expectedResult map[string]int64
+		expectNil      bool
+	}{
+		{
+			name:          "first call with prefix",
+			prefix:        "test_",
+			requestCount:  100,
+			eventCount:    500,
+			currentCounts: map[string]float64{"key1": 10, "key2": 20},
+			expectedResult: map[string]int64{
+				"test_request_count": 100,
+				"test_event_count":   500,
+				"test_keyspace_size": 2,
+			},
+		},
+		{
+			name:          "empty prefix",
+			prefix:        "",
+			requestCount:  42,
+			eventCount:    84,
+			currentCounts: map[string]float64{"key1": 5},
+			expectedResult: map[string]int64{
+				"request_count": 42,
+				"event_count":   84,
+				"keyspace_size": 1,
+			},
+		},
+		{
+			name:          "zero counts",
+			prefix:        "zero_",
+			requestCount:  0,
+			eventCount:    0,
+			currentCounts: map[string]float64{},
+			expectedResult: map[string]int64{
+				"zero_request_count": 0,
+				"zero_event_count":   0,
+				"zero_keyspace_size": 0,
+			},
+		},
+		{
+			name:         "large numbers",
+			prefix:       "large_",
+			requestCount: 1000000,
+			eventCount:   5000000,
+			currentCounts: map[string]float64{
+				"key1": 100, "key2": 200, "key3": 300, "key4": 400, "key5": 500,
+			},
+			expectedResult: map[string]int64{
+				"large_request_count": 1000000,
+				"large_event_count":   5000000,
+				"large_keyspace_size": 5,
+			},
+		},
+		{
+			name:           "same prefix second call",
+			prefix:         "same_",
+			requestCount:   200,
+			eventCount:     1000,
+			currentCounts:  map[string]float64{"key1": 15},
+			existingPrefix: "same_",
+			expectedResult: map[string]int64{
+				"same_request_count": 200,
+				"same_event_count":   1000,
+				"same_keyspace_size": 1,
+			},
+		},
+		{
+			name:           "different prefix returns nil",
+			prefix:         "new_",
+			requestCount:   150,
+			eventCount:     750,
+			currentCounts:  map[string]float64{"key1": 25},
+			existingPrefix: "old_",
+			expectNil:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AvgSampleRate{
+				requestCount:  tt.requestCount,
+				eventCount:    tt.eventCount,
+				currentCounts: tt.currentCounts,
+			}
+
+			// Set existing prefix if specified
+			if tt.existingPrefix != "" {
+				a.prefix = tt.existingPrefix
+				a.requestCountKey = a.prefix + requestCountSuffix
+				a.eventCountKey = a.prefix + eventCountSuffix
+				a.keyspaceSizeKey = a.prefix + keyspaceSizeSuffix
+			}
+
+			result := a.GetMetrics(tt.prefix)
+
+			if tt.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.NotNil(t, result)
+			assert.Equal(t, tt.expectedResult, result)
+
+			assert.Equal(t, tt.prefix, a.prefix)
+			assert.Equal(t, tt.prefix+requestCountSuffix, a.requestCountKey)
+			assert.Equal(t, tt.prefix+eventCountSuffix, a.eventCountKey)
+			assert.Equal(t, tt.prefix+keyspaceSizeSuffix, a.keyspaceSizeKey)
+		})
+	}
+}

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -289,3 +289,122 @@ func TestAvgSampleWithMin_Start(t *testing.T) {
 		})
 	}
 }
+
+func TestAvgSampleWithMin_GetMetrics(t *testing.T) {
+	tests := []struct {
+		name           string
+		prefix         string
+		requestCount   int64
+		eventCount     int64
+		currentCounts  map[string]float64
+		existingPrefix string
+		expectedResult map[string]int64
+		expectNil      bool
+	}{
+		{
+			name:          "first call with prefix",
+			prefix:        "test_",
+			requestCount:  100,
+			eventCount:    500,
+			currentCounts: map[string]float64{"key1": 10, "key2": 20},
+			expectedResult: map[string]int64{
+				"test_request_count": 100,
+				"test_event_count":   500,
+				"test_keyspace_size": 2,
+			},
+		},
+		{
+			name:          "empty prefix",
+			prefix:        "",
+			requestCount:  42,
+			eventCount:    84,
+			currentCounts: map[string]float64{"key1": 5},
+			expectedResult: map[string]int64{
+				"request_count": 42,
+				"event_count":   84,
+				"keyspace_size": 1,
+			},
+		},
+		{
+			name:          "zero counts",
+			prefix:        "zero_",
+			requestCount:  0,
+			eventCount:    0,
+			currentCounts: map[string]float64{},
+			expectedResult: map[string]int64{
+				"zero_request_count": 0,
+				"zero_event_count":   0,
+				"zero_keyspace_size": 0,
+			},
+		},
+		{
+			name:         "large numbers",
+			prefix:       "large_",
+			requestCount: 1000000,
+			eventCount:   5000000,
+			currentCounts: map[string]float64{
+				"key1": 100, "key2": 200, "key3": 300, "key4": 400, "key5": 500,
+			},
+			expectedResult: map[string]int64{
+				"large_request_count": 1000000,
+				"large_event_count":   5000000,
+				"large_keyspace_size": 5,
+			},
+		},
+		{
+			name:           "same prefix second call",
+			prefix:         "same_",
+			requestCount:   200,
+			eventCount:     1000,
+			currentCounts:  map[string]float64{"key1": 15},
+			existingPrefix: "same_",
+			expectedResult: map[string]int64{
+				"same_request_count": 200,
+				"same_event_count":   1000,
+				"same_keyspace_size": 1,
+			},
+		},
+		{
+			name:           "different prefix returns nil",
+			prefix:         "new_",
+			requestCount:   150,
+			eventCount:     750,
+			currentCounts:  map[string]float64{"key1": 25},
+			existingPrefix: "old_",
+			expectNil:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &AvgSampleWithMin{
+				requestCount:  tt.requestCount,
+				eventCount:    tt.eventCount,
+				currentCounts: tt.currentCounts,
+			}
+
+			// Set existing prefix if specified
+			if tt.existingPrefix != "" {
+				a.prefix = tt.existingPrefix
+				a.requestCountKey = a.prefix + requestCountSuffix
+				a.eventCountKey = a.prefix + eventCountSuffix
+				a.keyspaceSizeKey = a.prefix + keyspaceSizeSuffix
+			}
+
+			result := a.GetMetrics(tt.prefix)
+
+			if tt.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.NotNil(t, result)
+			assert.Equal(t, tt.expectedResult, result)
+
+			assert.Equal(t, tt.prefix, a.prefix)
+			assert.Equal(t, tt.prefix+requestCountSuffix, a.requestCountKey)
+			assert.Equal(t, tt.prefix+eventCountSuffix, a.eventCountKey)
+			assert.Equal(t, tt.prefix+keyspaceSizeSuffix, a.keyspaceSizeKey)
+		})
+	}
+}

--- a/dynsampler.go
+++ b/dynsampler.go
@@ -42,3 +42,12 @@ type Sampler interface {
 	// All names are prefixed with the given string.
 	GetMetrics(prefix string) map[string]int64
 }
+
+// metrics suffixes for the sampler
+const (
+	requestCountSuffix  = "request_count"
+	eventCountSuffix    = "event_count"
+	keyspaceSizeSuffix  = "keyspace_size"
+	burstCountSuffix    = "burst_count"
+	intervalCountSuffix = "interval_count"
+)

--- a/emasamplerate_test.go
+++ b/emasamplerate_test.go
@@ -533,3 +533,128 @@ func TestEMASampleRate_Start(t *testing.T) {
 		})
 	}
 }
+
+func TestEMASampleRate_GetMetrics(t *testing.T) {
+	tests := []struct {
+		name           string
+		prefix         string
+		requestCount   int64
+		eventCount     int64
+		currentCounts  map[string]float64
+		burstCount     int64
+		intervalCount  uint
+		existingPrefix string
+		expectedResult map[string]int64
+		expectNil      bool
+	}{
+		{
+			name:          "first call with prefix",
+			prefix:        "test_",
+			requestCount:  100,
+			eventCount:    500,
+			currentCounts: map[string]float64{"key1": 10, "key2": 20},
+			burstCount:    5,
+			intervalCount: 3,
+			expectedResult: map[string]int64{
+				"test_request_count":  100,
+				"test_event_count":    500,
+				"test_keyspace_size":  2,
+				"test_burst_count":    5,
+				"test_interval_count": 3,
+			},
+		},
+		{
+			name:          "empty prefix",
+			prefix:        "",
+			requestCount:  42,
+			eventCount:    84,
+			burstCount:    0,
+			intervalCount: 1,
+			currentCounts: map[string]float64{"key1": 5},
+			expectedResult: map[string]int64{
+				"request_count":  42,
+				"event_count":    84,
+				"burst_count":    0,
+				"interval_count": 1,
+				"keyspace_size":  1,
+			},
+		},
+		{
+			name:          "zero counts",
+			prefix:        "zero_",
+			currentCounts: map[string]float64{},
+			expectedResult: map[string]int64{
+				"zero_request_count":  0,
+				"zero_event_count":    0,
+				"zero_keyspace_size":  0,
+				"zero_burst_count":    0,
+				"zero_interval_count": 0,
+			},
+		},
+		{
+			name:           "same prefix second call",
+			prefix:         "same_",
+			requestCount:   200,
+			eventCount:     1000,
+			currentCounts:  map[string]float64{"key1": 15},
+			burstCount:     10,
+			intervalCount:  2,
+			existingPrefix: "same_",
+			expectedResult: map[string]int64{
+				"same_request_count":  200,
+				"same_event_count":    1000,
+				"same_keyspace_size":  1,
+				"same_burst_count":    10,
+				"same_interval_count": 2,
+			},
+		},
+		{
+			name:           "different prefix returns nil",
+			prefix:         "new_",
+			requestCount:   150,
+			eventCount:     750,
+			currentCounts:  map[string]float64{"key1": 25},
+			existingPrefix: "old_",
+			expectNil:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &EMASampleRate{
+				requestCount:  tt.requestCount,
+				eventCount:    tt.eventCount,
+				currentCounts: tt.currentCounts,
+				burstCount:    tt.burstCount,
+				intervalCount: tt.intervalCount,
+			}
+
+			// Set existing prefix if specified
+			if tt.existingPrefix != "" {
+				a.prefix = tt.existingPrefix
+				a.requestCountKey = a.prefix + requestCountSuffix
+				a.eventCountKey = a.prefix + eventCountSuffix
+				a.keyspaceSizeKey = a.prefix + keyspaceSizeSuffix
+				a.burstCountKey = a.prefix + burstCountSuffix
+				a.intervalCountKey = a.prefix + intervalCountSuffix
+			}
+
+			result := a.GetMetrics(tt.prefix)
+
+			if tt.expectNil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.NotNil(t, result)
+			assert.Equal(t, tt.expectedResult, result)
+
+			assert.Equal(t, tt.prefix, a.prefix)
+			assert.Equal(t, tt.prefix+requestCountSuffix, a.requestCountKey)
+			assert.Equal(t, tt.prefix+eventCountSuffix, a.eventCountKey)
+			assert.Equal(t, tt.prefix+keyspaceSizeSuffix, a.keyspaceSizeKey)
+			assert.Equal(t, tt.prefix+burstCountSuffix, a.burstCountKey)
+			assert.Equal(t, tt.prefix+intervalCountSuffix, a.intervalCountKey)
+		})
+	}
+}

--- a/emathroughput.go
+++ b/emathroughput.go
@@ -101,9 +101,15 @@ type EMAThroughput struct {
 	testSignalMapsDone chan struct{}
 
 	// metrics
-	requestCount int64
-	eventCount   int64
-	burstCount   int64
+	requestCount     int64
+	eventCount       int64
+	burstCount       int64
+	prefix           string
+	requestCountKey  string
+	eventCountKey    string
+	keyspaceSizeKey  string
+	burstCountKey    string
+	intervalCountKey string
 }
 
 // Ensure we implement the sampler interface
@@ -368,12 +374,26 @@ func (e *EMAThroughput) LoadState(state []byte) error {
 func (e *EMAThroughput) GetMetrics(prefix string) map[string]int64 {
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	mets := map[string]int64{
-		prefix + "request_count":  e.requestCount,
-		prefix + "event_count":    e.eventCount,
-		prefix + "burst_count":    e.burstCount,
-		prefix + "interval_count": int64(e.intervalCount),
-		prefix + "keyspace_size":  int64(len(e.currentCounts)),
+
+	if e.prefix == "" {
+		e.prefix = prefix
+		e.requestCountKey = e.prefix + requestCountSuffix
+		e.eventCountKey = e.prefix + eventCountSuffix
+		e.keyspaceSizeKey = e.prefix + keyspaceSizeSuffix
+		e.burstCountKey = e.prefix + burstCountSuffix
+		e.intervalCountKey = e.prefix + intervalCountSuffix
 	}
-	return mets
+
+	// If the prefix is set but does not match with the current prefix, return nil
+	if e.prefix != prefix {
+		return nil
+	}
+
+	return map[string]int64{
+		e.requestCountKey:  e.requestCount,
+		e.eventCountKey:    e.eventCount,
+		e.keyspaceSizeKey:  int64(len(e.currentCounts)),
+		e.burstCountKey:    e.burstCount,
+		e.intervalCountKey: int64(e.intervalCount),
+	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Generating the same metric name on each call to GetMetrics creates unnecessary heap allocation. This PR memoize the result after the first call to allow reuse of those keys

## Short description of the changes

- add metric key names to the Sampler struct
- memoize the result after first call
- add tests and benchmarks

I didn't change the GetMetrics signature to avoid breaking changes to the library

## Benchmark result
```
**OLD**
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/dynsampler-go
cpu: Apple M2 Max
BenchmarkEMAThroughputGetMetrics-12    	51280945	      218.2 ns/op	    376 B/op	      7 allocs/op
PASS
ok  	github.com/honeycombio/dynsampler-go	11.640s

**NEW**
goos: darwin
goarch: arm64
pkg: github.com/honeycombio/dynsampler-go
cpu: Apple M2 Max
BenchmarkEMAThroughputGetMetrics-12    	94783080	      109.9 ns/op	    256 B/op	      2 allocs/op
PASS
ok  	github.com/honeycombio/dynsampler-go	11.092s

```
