### PR TITLE
fix: use a newer go version in publish_github step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,9 @@ jobs:
           path: ./unit-tests.xml
 
   publish_github:
-    executor: go
+    executor:
+      name: go
+      goversion: 1.23
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Which problem is this PR solving?

The ghcr tool we use has updated to use `toolchain` in their go mod. This PR is to bump the go version used for the go executor in the `publish_github` step so that we can install the ghcr tool

## Short description of the changes

- bump go version for publish_github step

