### PR TITLE
fix: our Go executor takes a minor version as param

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
   publish_github:
     executor:
       name: go
-      goversion: "1.23"
+      goversion: "24"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Which problem is this PR solving?

- our Go executor takes a minor version as param
