### PR TITLE
fix: fix incorrect locking in WindowedThroughput

### DIFF
--- a/windowedthroughput.go
+++ b/windowedthroughput.go
@@ -191,6 +191,9 @@ func (t *WindowedThroughput) GetSampleRate(key string) int {
 // GetSampleRateMulti takes a key representing count spans and returns the
 // appropriate sample rate for that key.
 func (t *WindowedThroughput) GetSampleRateMulti(key string, count int) int {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	t.requestCount++
 	t.eventCount += int64(count)
 
@@ -203,8 +206,6 @@ func (t *WindowedThroughput) GetSampleRateMulti(key string, count int) int {
 		return 0
 	}
 
-	t.lock.Lock()
-	defer t.lock.Unlock()
 	if rate, found := t.savedSampleRates[key]; found {
 		return rate
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
We have a lock around some but not all fields on this struct... what?

## Short description of the changes
Just move the lock above all field updates.