### PR TITLE
feat: add SetGoalSampleRate method

### DIFF
--- a/avgsamplerate.go
+++ b/avgsamplerate.go
@@ -114,6 +114,7 @@ func (a *AvgSampleRate) updateMaps() {
 	a.lock.Lock()
 	tmpCounts := a.currentCounts
 	a.currentCounts = make(map[string]float64)
+	goalSampleRate := a.GoalSampleRate
 	a.lock.Unlock()
 	// short circuit if no traffic
 	numKeys := len(tmpCounts)
@@ -131,7 +132,7 @@ func (a *AvgSampleRate) updateMaps() {
 	for _, count := range tmpCounts {
 		sumEvents += count
 	}
-	goalCount := sumEvents / float64(a.GoalSampleRate)
+	goalCount := sumEvents / float64(goalSampleRate)
 	// goalRatio is the goalCount divided by the sum of all the log values - it
 	// determines what percentage of the total event space belongs to each key
 	var logSum float64
@@ -215,6 +216,15 @@ func (a *AvgSampleRate) LoadState(state []byte) error {
 	a.haveData = true
 
 	return nil
+}
+
+// SetGoalSampleRate updates the goal sample rate in a concurrency-safe manner
+func (a *AvgSampleRate) SetGoalSampleRate(rate int) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+	if rate > 0 {
+		a.GoalSampleRate = rate
+	}
 }
 
 func (a *AvgSampleRate) GetMetrics(prefix string) map[string]int64 {

--- a/avgsamplerate_test.go
+++ b/avgsamplerate_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSetGoalSampleRate(t *testing.T) {
+	a := &AvgSampleRate{
+		GoalSampleRate: 20,
+	}
+
+	// Test SetGoalSampleRate method
+	a.SetGoalSampleRate(25)
+	assert.Equal(t, 25, a.GoalSampleRate)
+
+	// Test that invalid values are ignored
+	a.SetGoalSampleRate(0)
+	assert.Equal(t, 25, a.GoalSampleRate)
+
+	a.SetGoalSampleRate(-5)
+	assert.Equal(t, 25, a.GoalSampleRate)
+}
+
 func TestAvgSampleUpdateMaps(t *testing.T) {
 	a := &AvgSampleRate{
 		GoalSampleRate: 20,

--- a/avgsamplewithmin_test.go
+++ b/avgsamplewithmin_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestAvgSampleWithMinSetGoalSampleRate(t *testing.T) {
+	a := &AvgSampleWithMin{
+		GoalSampleRate:         20,
+		MinEventsPerSec:        50,
+		ClearFrequencyDuration: 30 * time.Second,
+	}
+
+	// Test SetGoalSampleRate method
+	a.SetGoalSampleRate(30)
+	assert.Equal(t, 30, a.GoalSampleRate)
+
+	// Test that invalid values are ignored
+	a.SetGoalSampleRate(0)
+	assert.Equal(t, 30, a.GoalSampleRate)
+
+	a.SetGoalSampleRate(-5)
+	assert.Equal(t, 30, a.GoalSampleRate)
+}
+
 func TestAvgSampleWithMinUpdateMaps(t *testing.T) {
 	a := &AvgSampleWithMin{
 		GoalSampleRate:         20,

--- a/emasamplerate.go
+++ b/emasamplerate.go
@@ -215,9 +215,10 @@ func (e *EMASampleRate) updateMaps() {
 	// so we need to grab the lock when we update it.
 	e.lock.Lock()
 	e.burstThreshold = sumEvents * e.BurstMultiple
+	goalSampleRate := e.GoalSampleRate
 	e.lock.Unlock()
 
-	goalCount := float64(sumEvents) / float64(e.GoalSampleRate)
+	goalCount := float64(sumEvents) / float64(goalSampleRate)
 	// goalRatio is the goalCount divided by the sum of all the log values - it
 	// determines what percentage of the total event space belongs to each key
 	var logSum float64
@@ -361,6 +362,15 @@ func (e *EMASampleRate) LoadState(state []byte) error {
 	e.haveData = true
 
 	return nil
+}
+
+// SetGoalSampleRate updates the goal sample rate in a concurrency-safe manner
+func (e *EMASampleRate) SetGoalSampleRate(rate int) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	if rate > 0 {
+		e.GoalSampleRate = rate
+	}
 }
 
 func (e *EMASampleRate) GetMetrics(prefix string) map[string]int64 {

--- a/emasamplerate_test.go
+++ b/emasamplerate_test.go
@@ -45,6 +45,23 @@ func TestUpdateEMA(t *testing.T) {
 	}
 }
 
+func TestEMASampleRateSetGoalSampleRate(t *testing.T) {
+	e := &EMASampleRate{
+		GoalSampleRate: 10,
+	}
+
+	// Test SetGoalSampleRate method
+	e.SetGoalSampleRate(15)
+	assert.Equal(t, 15, e.GoalSampleRate)
+
+	// Test that invalid values are ignored
+	e.SetGoalSampleRate(0)
+	assert.Equal(t, 15, e.GoalSampleRate)
+
+	e.SetGoalSampleRate(-5)
+	assert.Equal(t, 15, e.GoalSampleRate)
+}
+
 func TestEMASampleGetSampleRateStartup(t *testing.T) {
 	e := &EMASampleRate{
 		GoalSampleRate: 10,

--- a/emathroughput.go
+++ b/emathroughput.go
@@ -220,11 +220,12 @@ func (e *EMAThroughput) updateMaps() {
 	// so we need to grab the lock when we update it.
 	e.lock.Lock()
 	e.burstThreshold = sumEvents * e.BurstMultiple
+	goalThroughputPerSec := e.GoalThroughputPerSec
 	e.lock.Unlock()
 
 	// Calculate the desired average sample rate per second based on the volume we've received.
 	// This is the number of events we'd like to let through per adjustment interval.
-	goalCount := float64(e.GoalThroughputPerSec) * e.AdjustmentInterval.Seconds()
+	goalCount := float64(goalThroughputPerSec) * e.AdjustmentInterval.Seconds()
 
 	// goalRatio is the goalCount divided by the sum of all the log values - it
 	// determines what percentage of the total event space belongs to each key
@@ -369,6 +370,15 @@ func (e *EMAThroughput) LoadState(state []byte) error {
 	e.haveData = true
 
 	return nil
+}
+
+// SetGoalThroughputPerSec updates the goal throughput per second in a concurrency-safe manner
+func (e *EMAThroughput) SetGoalThroughputPerSec(throughput int) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	if throughput > 0 {
+		e.GoalThroughputPerSec = throughput
+	}
 }
 
 func (e *EMAThroughput) GetMetrics(prefix string) map[string]int64 {

--- a/emathroughput_test.go
+++ b/emathroughput_test.go
@@ -9,6 +9,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestEMAThroughputSetGoalThroughputPerSec(t *testing.T) {
+	e := &EMAThroughput{
+		GoalThroughputPerSec: 100,
+	}
+
+	// Test SetGoalThroughputPerSec method
+	e.SetGoalThroughputPerSec(200)
+	assert.Equal(t, 200, e.GoalThroughputPerSec)
+
+	// Test that invalid values are ignored
+	e.SetGoalThroughputPerSec(0)
+	assert.Equal(t, 200, e.GoalThroughputPerSec)
+
+	e.SetGoalThroughputPerSec(-10)
+	assert.Equal(t, 200, e.GoalThroughputPerSec)
+}
+
 func TestUpdateEMAThroughput(t *testing.T) {
 	e := &EMAThroughput{
 		movingAverage: make(map[string]float64),

--- a/totalthroughput.go
+++ b/totalthroughput.go
@@ -108,6 +108,7 @@ func (t *TotalThroughput) updateMaps() {
 	t.lock.Lock()
 	tmpCounts := t.currentCounts
 	t.currentCounts = make(map[string]int)
+	goalThroughputPerSec := t.GoalThroughputPerSec
 	t.lock.Unlock()
 	// short circuit if no traffic
 	numKeys := len(tmpCounts)
@@ -119,7 +120,7 @@ func (t *TotalThroughput) updateMaps() {
 		return
 	}
 	// figure out our target throughput per key over ClearFrequencyDuration
-	totalGoalThroughput := float64(t.GoalThroughputPerSec) * t.ClearFrequencyDuration.Seconds()
+	totalGoalThroughput := float64(goalThroughputPerSec) * t.ClearFrequencyDuration.Seconds()
 	// split the total throughput equally across the number of keys.
 	throughputPerKey := float64(totalGoalThroughput) / float64(numKeys)
 	// for each key, calculate sample rate by dividing counted events by the
@@ -173,6 +174,15 @@ func (t *TotalThroughput) SaveState() ([]byte, error) {
 // LoadState is not implemented
 func (t *TotalThroughput) LoadState(state []byte) error {
 	return nil
+}
+
+// SetGoalThroughputPerSec updates the goal throughput per second in a concurrency-safe manner
+func (t *TotalThroughput) SetGoalThroughputPerSec(throughput int) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if throughput > 0 {
+		t.GoalThroughputPerSec = throughput
+	}
 }
 
 func (t *TotalThroughput) GetMetrics(prefix string) map[string]int64 {

--- a/totalthroughput_test.go
+++ b/totalthroughput_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestTotalThroughputSetGoalThroughputPerSec(t *testing.T) {
+	s := &TotalThroughput{
+		GoalThroughputPerSec: 100,
+	}
+
+	// Test SetGoalThroughputPerSec method
+	s.SetGoalThroughputPerSec(200)
+	assert.Equal(t, 200, s.GoalThroughputPerSec)
+
+	// Test that invalid values are ignored
+	s.SetGoalThroughputPerSec(0)
+	assert.Equal(t, 200, s.GoalThroughputPerSec)
+
+	s.SetGoalThroughputPerSec(-10)
+	assert.Equal(t, 200, s.GoalThroughputPerSec)
+}
+
 func TestTotalThroughputUpdateMaps(t *testing.T) {
 	s := &TotalThroughput{
 		ClearFrequencyDuration: 30 * time.Second,

--- a/windowedthroughput.go
+++ b/windowedthroughput.go
@@ -226,11 +226,11 @@ func (t *WindowedThroughput) LoadState(state []byte) error {
 }
 
 // SetGoalThroughputPerSec updates the goal throughput per second in a concurrency-safe manner
-func (t *WindowedThroughput) SetGoalThroughputPerSec(throughput float64) {
+func (t *WindowedThroughput) SetGoalThroughputPerSec(throughput int) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	if throughput > 0 {
-		t.GoalThroughputPerSec = throughput
+		t.GoalThroughputPerSec = float64(throughput)
 	}
 }
 

--- a/windowedthroughput.go
+++ b/windowedthroughput.go
@@ -165,7 +165,10 @@ func (t *WindowedThroughput) updateMaps() {
 		return
 	}
 	// figure out our target throughput per key over the lookback window.
-	totalGoalThroughput := t.GoalThroughputPerSec * t.LookbackFrequencyDuration.Seconds()
+	t.lock.Lock()
+	goalThroughputPerSec := t.GoalThroughputPerSec
+	t.lock.Unlock()
+	totalGoalThroughput := goalThroughputPerSec * t.LookbackFrequencyDuration.Seconds()
 	// split the total throughput equally across the number of keys.
 	throughputPerKey := float64(totalGoalThroughput) / float64(numKeys)
 	// for each key, calculate sample rate by dividing counted events by the
@@ -220,6 +223,15 @@ func (t *WindowedThroughput) SaveState() ([]byte, error) {
 // LoadState is not implemented
 func (t *WindowedThroughput) LoadState(state []byte) error {
 	return nil
+}
+
+// SetGoalThroughputPerSec updates the goal throughput per second in a concurrency-safe manner
+func (t *WindowedThroughput) SetGoalThroughputPerSec(throughput float64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	if throughput > 0 {
+		t.GoalThroughputPerSec = throughput
+	}
 }
 
 func (t *WindowedThroughput) GetMetrics(prefix string) map[string]int64 {

--- a/windowedthroughput_test.go
+++ b/windowedthroughput_test.go
@@ -10,6 +10,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestWindowedThroughputSetGoalThroughputPerSec(t *testing.T) {
+	s := &WindowedThroughput{
+		GoalThroughputPerSec: 100.0,
+	}
+
+	// Test SetGoalThroughputPerSec method
+	s.SetGoalThroughputPerSec(200.5)
+	assert.Equal(t, 200.5, s.GoalThroughputPerSec)
+
+	// Test that invalid values are ignored
+	s.SetGoalThroughputPerSec(0)
+	assert.Equal(t, 200.5, s.GoalThroughputPerSec)
+
+	s.SetGoalThroughputPerSec(-10.5)
+	assert.Equal(t, 200.5, s.GoalThroughputPerSec)
+}
+
 type TestIndexGenerator struct {
 	CurrentIndex int64
 }

--- a/windowedthroughput_test.go
+++ b/windowedthroughput_test.go
@@ -16,15 +16,15 @@ func TestWindowedThroughputSetGoalThroughputPerSec(t *testing.T) {
 	}
 
 	// Test SetGoalThroughputPerSec method
-	s.SetGoalThroughputPerSec(200.5)
-	assert.Equal(t, 200.5, s.GoalThroughputPerSec)
+	s.SetGoalThroughputPerSec(200)
+	assert.Equal(t, 200.0, s.GoalThroughputPerSec)
 
 	// Test that invalid values are ignored
 	s.SetGoalThroughputPerSec(0)
-	assert.Equal(t, 200.5, s.GoalThroughputPerSec)
+	assert.Equal(t, 200.0, s.GoalThroughputPerSec)
 
-	s.SetGoalThroughputPerSec(-10.5)
-	assert.Equal(t, 200.5, s.GoalThroughputPerSec)
+	s.SetGoalThroughputPerSec(-10)
+	assert.Equal(t, 200.0, s.GoalThroughputPerSec)
 }
 
 type TestIndexGenerator struct {


### PR DESCRIPTION
## Which problem is this PR solving?
Refinery samplers write to GoalSampleRate at runtime when the cluster size changes, but this code's concurrency controls assume it's an immutable value that doesn't need protection.

## Short description of the changes
Adds appropriate locking and a Set method so we can update GoalSampleRate without external locking.
