### PR TITLE
maint: add Go 1.25 to the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["20", "21", "22", "23", "24"]
+      goversion: ["20", "21", "22", "23", "24", "25"]
 
 # Default version of Go to use for Go steps
 default_goversion: &default_goversion "20"


### PR DESCRIPTION
## Which problem is this PR solving?

Confirm this library works under Go 1.25. (FINE-21)

## Short description of the changes

- Add Go 1.25 to the test matrix.

