### PR TITLE
chore: add oss-maintainers to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/llm-observability @honeycombio/ai-observability
+* @honeycombio/llm-observability @honeycombio/ai-observability @honeycombio/oss-maintainers


### PR DESCRIPTION
## Which problem is this PR solving?

Add OTel team as codeowners



