### PR TITLE
chore: remove llm-o11y and ai-o11y from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/llm-observability @honeycombio/ai-observability @honeycombio/oss-maintainers
+* @honeycombio/oss-maintainers


### PR DESCRIPTION
## Which problem is this PR solving?

- remove llm-o11y and ai-o11y from codeowners file

